### PR TITLE
Remove italic from ts_comment to match Emacs defaults

### DIFF
--- a/colors/modus-operandi-deuteranopia.kak
+++ b/colors/modus-operandi-deuteranopia.kak
@@ -21,8 +21,8 @@ declare-option str blue_bright 'rgb:0000b0'
 declare-option str purple 'rgb:721045'
 declare-option str purple_bright 'rgb:531ab6'
 declare-option str bg_mode_line 'rgb:d0d6ff'
-declare-option str fg_mode_line 'rgb:000000'
-declare-option str cursor 'rgb:000000'
+declare-option str fg_mode_line 'rgb:0f0f0f'
+declare-option str cursor 'rgb:0000ff'
 declare-option str bg_hl_line 'rgb:dae5ec'
 declare-option str fg_space 'rgb:9f9f9f'
 declare-option str magenta_warmer 'rgb:8f0075'
@@ -38,6 +38,7 @@ declare-option str magenta_faint 'rgb:7c318f'
 declare-option str cyan_faint 'rgb:005077'
 declare-option str fg_link 'rgb:3548cf'
 declare-option str fg_prose_code 'rgb:005f5f'
+declare-option str yellow_warmer 'rgb:973300'
 
 declare-option str psel 'rgb:bdbdbd'
 declare-option str ssel 'rgb:dae5ec'
@@ -48,14 +49,14 @@ declare-option str ssel 'rgb:dae5ec'
 set-face global value 'rgb:000000'
 set-face global type 'rgb:005f5f'
 set-face global variable 'rgb:005e8b'
-set-face global keyword 'rgb:531ab6'
+set-face global keyword 'rgb:0000b0'
 set-face global module 'rgb:000000'
-set-face global function 'rgb:721045'
+set-face global function 'rgb:973300'
 set-face global string 'rgb:3548cf'
-set-face global builtin 'rgb:8f0075'
-set-face global constant 'rgb:0000b0'
+set-face global builtin 'rgb:695500'
+set-face global constant 'rgb:003497'
 set-face global comment 'rgb:77492f'
-set-face global meta 'rgb:a0132f'
+set-face global meta 'rgb:531ab6'
 
 set-face global operator 'rgb:000000'
 set-face global comma 'rgb:000000'
@@ -101,21 +102,21 @@ set-face global BufferPadding "%opt{bg_main},%opt{bg_main}"
 
 # For tree-sitter (kak-tree-sitter)
 # -- Keywords --
-set-face global ts_keyword                      "%opt{purple_bright}"
-set-face global ts_keyword_conditional          "%opt{purple_bright}+i"
-set-face global ts_keyword_control_conditional  "%opt{purple_bright}+i"
-set-face global ts_keyword_control_import       "%opt{purple_bright}+i"
-set-face global ts_keyword_directive            "%opt{red_bright}+i"
-set-face global ts_keyword_storage              "%opt{purple_bright}"
-set-face global ts_keyword_storage_modifier     "%opt{purple_bright}"
-set-face global ts_keyword_storage_modifier_mut "%opt{purple_bright}"
+set-face global ts_keyword                      "%opt{blue_bright}"
+set-face global ts_keyword_conditional          "%opt{blue_bright}+i"
+set-face global ts_keyword_control_conditional  "%opt{blue_bright}+i"
+set-face global ts_keyword_control_import       "%opt{blue_bright}+i"
+set-face global ts_keyword_directive            "%opt{purple_bright}+i"
+set-face global ts_keyword_storage              "%opt{blue_bright}"
+set-face global ts_keyword_storage_modifier     "%opt{blue_bright}"
+set-face global ts_keyword_storage_modifier_mut "%opt{blue_bright}"
 set-face global ts_keyword_storage_modifier_ref "%opt{cyan_cooler}"
 
 # -- Functions --
-set-face global ts_function                     "%opt{purple}"
-set-face global ts_function_builtin             "%opt{magenta_warmer}+i"
-set-face global ts_function_macro               "%opt{red_bright}"
-set-face global ts_function_method              "%opt{purple}"
+set-face global ts_function                     "%opt{yellow_warmer}"
+set-face global ts_function_builtin             "%opt{yellow}+i"
+set-face global ts_function_macro               "%opt{purple_bright}"
+set-face global ts_function_method              "%opt{yellow_warmer}"
 
 # -- Types --
 set-face global ts_type                         "%opt{cyan_cooler}"
@@ -126,39 +127,39 @@ set-face global ts_constructor                  "%opt{cyan_cooler}"
 
 # -- Strings --
 set-face global ts_string                       "%opt{blue_warmer}"
-set-face global ts_string_regexp                "%opt{green_bright}"
-set-face global ts_string_escape                "%opt{purple}"
+set-face global ts_string_regexp                "%opt{yellow_bright}"
+set-face global ts_string_escape                "%opt{blue_bright}"
 set-face global ts_string_special               "%opt{blue}"
 set-face global ts_string_special_path          "%opt{green_bright}"
-set-face global ts_string_special_symbol        "%opt{purple_bright}"
-set-face global ts_string_symbol                "%opt{red_bright}"
+set-face global ts_string_special_symbol        "%opt{blue_bright}"
+set-face global ts_string_symbol                "%opt{purple_bright}"
 
 # -- Constants --
-set-face global ts_constant                     "%opt{blue_bright}"
-set-face global ts_constant_builtin             "%opt{blue_bright}"
-set-face global ts_constant_builtin_boolean     "%opt{blue_bright}"
-set-face global ts_constant_character           "%opt{blue_bright}"
-set-face global ts_constant_macro               "%opt{red_bright}"
-set-face global ts_constant_numeric             "%opt{blue_bright}"
+set-face global ts_constant                     "%opt{blue_faint}"
+set-face global ts_constant_builtin             "%opt{blue_faint}"
+set-face global ts_constant_builtin_boolean     "%opt{blue_faint}"
+set-face global ts_constant_character           "%opt{blue_faint}"
+set-face global ts_constant_macro               "%opt{purple_bright}"
+set-face global ts_constant_numeric             "%opt{fg_main}"
 
 # -- Variables --
 set-face global ts_variable                     "%opt{cyan}"
-set-face global ts_variable_builtin             "%opt{purple_bright}"
+set-face global ts_variable_builtin             "%opt{blue_bright}"
 set-face global ts_variable_other_member        "%opt{cyan_warmer}"
 set-face global ts_variable_parameter           "%opt{cyan}+i"
 
 # -- Comments & operators --
-set-face global ts_comment                      "%opt{fg_dim}+i"
-set-face global ts_comment_unused               "%opt{fg_dim}+is"
+set-face global ts_comment                      "%opt{yellow_bright}+i"
+set-face global ts_comment_unused               "%opt{yellow_bright}+is"
 set-face global ts_operator                     "%opt{fg_main}"
-set-face global ts_punctuation                  "%opt{fg_dim}"
-set-face global ts_punctuation_special          "%opt{purple_bright}"
+set-face global ts_punctuation                  "%opt{fg_main}"
+set-face global ts_punctuation_special          "%opt{blue_bright}"
 
 # -- Properties, namespaces, labels --
 set-face global ts_property                     "%opt{cyan}"
-set-face global ts_namespace                    "%opt{cyan}+i"
+set-face global ts_namespace                    "%opt{cyan_cooler}+i"
 set-face global ts_label                        "%opt{cyan}+i"
-set-face global ts_attribute                    "%opt{red_bright}"
+set-face global ts_attribute                    "%opt{purple_bright}"
 
 # -- Markup --
 set-face global ts_markup_bold                  "%opt{fg_main}+b"
@@ -196,10 +197,10 @@ set-face global ts_hint                         "%opt{blue}+b"
 set-face global ts_info                         "%opt{green}+b"
 
 # -- Others --
-set-face global ts_embedded                     "%opt{purple_bright}"
-set-face global ts_include                      "%opt{purple_bright}"
-set-face global ts_load                         "%opt{purple_bright}"
-set-face global ts_tag                          "%opt{purple_bright}"
+set-face global ts_embedded                     "%opt{blue_bright}"
+set-face global ts_include                      "%opt{blue_bright}"
+set-face global ts_load                         "%opt{blue_bright}"
+set-face global ts_tag                          "%opt{blue_bright}"
 set-face global ts_tag_error                    "%opt{red}"
 set-face global ts_text                         "%opt{fg_main}"
 set-face global ts_text_title                   "%opt{fg_main}+b"

--- a/colors/modus-operandi-deuteranopia.kak
+++ b/colors/modus-operandi-deuteranopia.kak
@@ -149,8 +149,8 @@ set-face global ts_variable_other_member        "%opt{cyan_warmer}"
 set-face global ts_variable_parameter           "%opt{cyan}+i"
 
 # -- Comments & operators --
-set-face global ts_comment                      "%opt{yellow_bright}+i"
-set-face global ts_comment_unused               "%opt{yellow_bright}+is"
+set-face global ts_comment                      "%opt{yellow_bright}"
+set-face global ts_comment_unused               "%opt{yellow_bright}+s"
 set-face global ts_operator                     "%opt{fg_main}"
 set-face global ts_punctuation                  "%opt{fg_main}"
 set-face global ts_punctuation_special          "%opt{blue_bright}"

--- a/colors/modus-operandi-deuteranopia.kak
+++ b/colors/modus-operandi-deuteranopia.kak
@@ -30,6 +30,14 @@ declare-option str blue_warmer 'rgb:3548cf'
 declare-option str cyan 'rgb:005e8b'
 declare-option str cyan_warmer 'rgb:3f578f'
 declare-option str cyan_cooler 'rgb:005f5f'
+declare-option str red_faint 'rgb:7f0000'
+declare-option str green_faint 'rgb:2a5045'
+declare-option str yellow_faint 'rgb:624416'
+declare-option str blue_faint 'rgb:003497'
+declare-option str magenta_faint 'rgb:7c318f'
+declare-option str cyan_faint 'rgb:005077'
+declare-option str fg_link 'rgb:3548cf'
+declare-option str fg_prose_code 'rgb:005f5f'
 
 declare-option str psel 'rgb:bdbdbd'
 declare-option str ssel 'rgb:dae5ec'
@@ -54,14 +62,14 @@ set-face global comma 'rgb:000000'
 set-face global bracket 'rgb:5fcfff'
 
 # For markup
-set-face global title "%opt{purple}"
-set-face global header "%opt{yellow_bright}"
-set-face global bold "%opt{purple}"
-set-face global italic "%opt{purple_bright}"
-set-face global mono "%opt{green}"
-set-face global block "%opt{blue_bright}"
-set-face global link "%opt{green}"
-set-face global bullet "%opt{green}"
+set-face global title "%opt{fg_main}+b"
+set-face global header "%opt{fg_main}+b"
+set-face global bold "%opt{fg_main}+b"
+set-face global italic "%opt{fg_main}+i"
+set-face global mono "%opt{fg_prose_code}"
+set-face global block "%opt{fg_dim}"
+set-face global link "%opt{fg_link}+u"
+set-face global bullet "%opt{fg_dim}"
 set-face global list "%opt{fg_main}"
 
 # Builtin faces
@@ -157,23 +165,23 @@ set-face global ts_markup_bold                  "%opt{fg_main}+b"
 set-face global ts_markup_italic                "%opt{fg_main}+i"
 set-face global ts_markup_strikethrough         "%opt{fg_dim}+s"
 set-face global ts_markup_heading               "%opt{fg_main}+b"
-set-face global ts_markup_heading_1             "%opt{red}+b"
-set-face global ts_markup_heading_2             "%opt{purple_bright}+b"
-set-face global ts_markup_heading_3             "%opt{green}+b"
-set-face global ts_markup_heading_4             "%opt{yellow}+b"
-set-face global ts_markup_heading_5             "%opt{purple}+b"
-set-face global ts_markup_heading_6             "%opt{cyan}+b"
-set-face global ts_markup_heading_marker        "%opt{red}+b"
-set-face global ts_markup_list_checked          "%opt{green}"
-set-face global ts_markup_list_numbered         "%opt{blue}+i"
-set-face global ts_markup_list_unchecked        "%opt{cyan}"
-set-face global ts_markup_list_unnumbered       "%opt{purple_bright}"
-set-face global ts_markup_link_label            "%opt{blue}"
-set-face global ts_markup_link_url              "%opt{cyan}+u"
-set-face global ts_markup_link_uri              "%opt{cyan}+u"
-set-face global ts_markup_link_text             "%opt{blue}"
-set-face global ts_markup_quote                 "%opt{fg_dim}+i"
-set-face global ts_markup_raw                   "%opt{green_bright}"
+set-face global ts_markup_heading_1             "%opt{fg_main}+b"
+set-face global ts_markup_heading_2             "%opt{yellow_faint}+b"
+set-face global ts_markup_heading_3             "%opt{blue_faint}+b"
+set-face global ts_markup_heading_4             "%opt{green_faint}+b"
+set-face global ts_markup_heading_5             "%opt{purple_bright}+b"
+set-face global ts_markup_heading_6             "%opt{yellow_bright}+b"
+set-face global ts_markup_heading_marker        "%opt{fg_dim}"
+set-face global ts_markup_list_checked          "%opt{fg_dim}"
+set-face global ts_markup_list_numbered         "%opt{fg_dim}"
+set-face global ts_markup_list_unchecked        "%opt{fg_dim}"
+set-face global ts_markup_list_unnumbered       "%opt{fg_dim}"
+set-face global ts_markup_link_label            "%opt{fg_link}"
+set-face global ts_markup_link_url              "%opt{fg_alt}"
+set-face global ts_markup_link_uri              "%opt{fg_alt}"
+set-face global ts_markup_link_text             "%opt{fg_link}+u"
+set-face global ts_markup_quote                 "%opt{fg_main}+i"
+set-face global ts_markup_raw                   "%opt{fg_prose_code}"
 
 # -- Diff --
 set-face global ts_diff_plus                    "%opt{green}"
@@ -194,7 +202,7 @@ set-face global ts_load                         "%opt{purple_bright}"
 set-face global ts_tag                          "%opt{purple_bright}"
 set-face global ts_tag_error                    "%opt{red}"
 set-face global ts_text                         "%opt{fg_main}"
-set-face global ts_text_title                   "%opt{purple_bright}+b"
+set-face global ts_text_title                   "%opt{fg_main}+b"
 set-face global ts_conceal                      "%opt{fg_dim}+i"
 set-face global ts_special                      "%opt{blue}"
 set-face global ts_spell                        "%opt{fg_main}"

--- a/colors/modus-operandi-tinted.kak
+++ b/colors/modus-operandi-tinted.kak
@@ -150,8 +150,8 @@ set-face global ts_variable_other_member        "%opt{green_bright}"
 set-face global ts_variable_parameter           "%opt{green_bright}+i"
 
 # -- Comments & operators --
-set-face global ts_comment                      "%opt{red_faint}+i"
-set-face global ts_comment_unused               "%opt{red_faint}+is"
+set-face global ts_comment                      "%opt{red_faint}"
+set-face global ts_comment_unused               "%opt{red_faint}+s"
 set-face global ts_operator                     "%opt{fg_main}"
 set-face global ts_punctuation                  "%opt{fg_main}"
 set-face global ts_punctuation_special          "%opt{blue}"

--- a/colors/modus-operandi-tinted.kak
+++ b/colors/modus-operandi-tinted.kak
@@ -22,7 +22,7 @@ declare-option str purple 'rgb:721045'
 declare-option str purple_bright 'rgb:531ab6'
 declare-option str bg_mode_line 'rgb:cab9b2'
 declare-option str fg_mode_line 'rgb:000000'
-declare-option str cursor 'rgb:000000'
+declare-option str cursor 'rgb:d00000'
 declare-option str bg_hl_line 'rgb:f1d5d0'
 declare-option str fg_space 'rgb:9f9690'
 declare-option str magenta_warmer 'rgb:8f0075'
@@ -38,6 +38,8 @@ declare-option str magenta_faint 'rgb:7c318f'
 declare-option str cyan_faint 'rgb:304463'
 declare-option str fg_link 'rgb:3546c2'
 declare-option str fg_prose_code 'rgb:00603f'
+declare-option str green_warmer 'rgb:306010'
+declare-option str yellow_warmer 'rgb:894000'
 
 declare-option str psel 'rgb:c2bcb5'
 declare-option str ssel 'rgb:f1d5d0'
@@ -46,16 +48,16 @@ declare-option str ssel 'rgb:f1d5d0'
 # https://github.com/mawww/kakoune/blob/master/colors/default.kak
 # For code
 set-face global value 'rgb:000000'
-set-face global type 'rgb:005f5f'
-set-face global variable 'rgb:00598b'
-set-face global keyword 'rgb:531ab6'
+set-face global type 'rgb:306010'
+set-face global variable 'rgb:00603f'
+set-face global keyword 'rgb:0031a9'
 set-face global module 'rgb:000000'
-set-face global function 'rgb:721045'
-set-face global string 'rgb:3546c2'
-set-face global builtin 'rgb:8f0075'
-set-face global constant 'rgb:0000b0'
+set-face global function 'rgb:602938'
+set-face global string 'rgb:00598b'
+set-face global builtin 'rgb:721045'
+set-face global constant 'rgb:531ab6'
 set-face global comment 'rgb:7f0000'
-set-face global meta 'rgb:a0132f'
+set-face global meta 'rgb:894000'
 
 set-face global operator 'rgb:000000'
 set-face global comma 'rgb:000000'
@@ -101,64 +103,64 @@ set-face global BufferPadding "%opt{bg_main},%opt{bg_main}"
 
 # For tree-sitter (kak-tree-sitter)
 # -- Keywords --
-set-face global ts_keyword                      "%opt{purple_bright}"
-set-face global ts_keyword_conditional          "%opt{purple_bright}+i"
-set-face global ts_keyword_control_conditional  "%opt{purple_bright}+i"
-set-face global ts_keyword_control_import       "%opt{purple_bright}+i"
-set-face global ts_keyword_directive            "%opt{red_bright}+i"
-set-face global ts_keyword_storage              "%opt{purple_bright}"
-set-face global ts_keyword_storage_modifier     "%opt{purple_bright}"
-set-face global ts_keyword_storage_modifier_mut "%opt{purple_bright}"
-set-face global ts_keyword_storage_modifier_ref "%opt{cyan_cooler}"
+set-face global ts_keyword                      "%opt{blue}"
+set-face global ts_keyword_conditional          "%opt{blue}+i"
+set-face global ts_keyword_control_conditional  "%opt{blue}+i"
+set-face global ts_keyword_control_import       "%opt{blue}+i"
+set-face global ts_keyword_directive            "%opt{yellow_warmer}+i"
+set-face global ts_keyword_storage              "%opt{blue}"
+set-face global ts_keyword_storage_modifier     "%opt{blue}"
+set-face global ts_keyword_storage_modifier_mut "%opt{blue}"
+set-face global ts_keyword_storage_modifier_ref "%opt{green_warmer}"
 
 # -- Functions --
-set-face global ts_function                     "%opt{purple}"
-set-face global ts_function_builtin             "%opt{magenta_warmer}+i"
-set-face global ts_function_macro               "%opt{red_bright}"
-set-face global ts_function_method              "%opt{purple}"
+set-face global ts_function                     "%opt{yellow_bright}"
+set-face global ts_function_builtin             "%opt{purple}+i"
+set-face global ts_function_macro               "%opt{yellow_warmer}"
+set-face global ts_function_method              "%opt{yellow_bright}"
 
 # -- Types --
-set-face global ts_type                         "%opt{cyan_cooler}"
-set-face global ts_type_builtin                 "%opt{cyan_cooler}"
-set-face global ts_type_enum_variant            "%opt{cyan_warmer}"
-set-face global ts_type_parameter               "%opt{cyan}+i"
-set-face global ts_constructor                  "%opt{cyan_cooler}"
+set-face global ts_type                         "%opt{green_warmer}"
+set-face global ts_type_builtin                 "%opt{green_warmer}"
+set-face global ts_type_enum_variant            "%opt{cyan_cooler}"
+set-face global ts_type_parameter               "%opt{green_bright}+i"
+set-face global ts_constructor                  "%opt{green_warmer}"
 
 # -- Strings --
-set-face global ts_string                       "%opt{blue_warmer}"
-set-face global ts_string_regexp                "%opt{green_bright}"
-set-face global ts_string_escape                "%opt{purple}"
-set-face global ts_string_special               "%opt{blue}"
+set-face global ts_string                       "%opt{cyan}"
+set-face global ts_string_regexp                "%opt{purple_bright}"
+set-face global ts_string_escape                "%opt{magenta_warmer}"
+set-face global ts_string_special               "%opt{cyan}"
 set-face global ts_string_special_path          "%opt{green_bright}"
-set-face global ts_string_special_symbol        "%opt{purple_bright}"
-set-face global ts_string_symbol                "%opt{red_bright}"
+set-face global ts_string_special_symbol        "%opt{blue}"
+set-face global ts_string_symbol                "%opt{yellow_warmer}"
 
 # -- Constants --
-set-face global ts_constant                     "%opt{blue_bright}"
-set-face global ts_constant_builtin             "%opt{blue_bright}"
-set-face global ts_constant_builtin_boolean     "%opt{blue_bright}"
-set-face global ts_constant_character           "%opt{blue_bright}"
-set-face global ts_constant_macro               "%opt{red_bright}"
-set-face global ts_constant_numeric             "%opt{blue_bright}"
+set-face global ts_constant                     "%opt{purple_bright}"
+set-face global ts_constant_builtin             "%opt{purple_bright}"
+set-face global ts_constant_builtin_boolean     "%opt{purple_bright}"
+set-face global ts_constant_character           "%opt{purple_bright}"
+set-face global ts_constant_macro               "%opt{yellow_warmer}"
+set-face global ts_constant_numeric             "%opt{fg_main}"
 
 # -- Variables --
-set-face global ts_variable                     "%opt{cyan}"
-set-face global ts_variable_builtin             "%opt{purple_bright}"
-set-face global ts_variable_other_member        "%opt{cyan_warmer}"
-set-face global ts_variable_parameter           "%opt{cyan}+i"
+set-face global ts_variable                     "%opt{green_bright}"
+set-face global ts_variable_builtin             "%opt{blue}"
+set-face global ts_variable_other_member        "%opt{green_bright}"
+set-face global ts_variable_parameter           "%opt{green_bright}+i"
 
 # -- Comments & operators --
-set-face global ts_comment                      "%opt{fg_dim}+i"
-set-face global ts_comment_unused               "%opt{fg_dim}+is"
+set-face global ts_comment                      "%opt{red_faint}+i"
+set-face global ts_comment_unused               "%opt{red_faint}+is"
 set-face global ts_operator                     "%opt{fg_main}"
-set-face global ts_punctuation                  "%opt{fg_dim}"
-set-face global ts_punctuation_special          "%opt{purple_bright}"
+set-face global ts_punctuation                  "%opt{fg_main}"
+set-face global ts_punctuation_special          "%opt{blue}"
 
 # -- Properties, namespaces, labels --
-set-face global ts_property                     "%opt{cyan}"
-set-face global ts_namespace                    "%opt{cyan}+i"
-set-face global ts_label                        "%opt{cyan}+i"
-set-face global ts_attribute                    "%opt{red_bright}"
+set-face global ts_property                     "%opt{green_bright}"
+set-face global ts_namespace                    "%opt{green_warmer}+i"
+set-face global ts_label                        "%opt{green_bright}+i"
+set-face global ts_attribute                    "%opt{yellow_warmer}"
 
 # -- Markup --
 set-face global ts_markup_bold                  "%opt{fg_main}+b"
@@ -196,10 +198,10 @@ set-face global ts_hint                         "%opt{blue}+b"
 set-face global ts_info                         "%opt{green}+b"
 
 # -- Others --
-set-face global ts_embedded                     "%opt{purple_bright}"
-set-face global ts_include                      "%opt{purple_bright}"
-set-face global ts_load                         "%opt{purple_bright}"
-set-face global ts_tag                          "%opt{purple_bright}"
+set-face global ts_embedded                     "%opt{blue}"
+set-face global ts_include                      "%opt{blue}"
+set-face global ts_load                         "%opt{blue}"
+set-face global ts_tag                          "%opt{blue}"
 set-face global ts_tag_error                    "%opt{red}"
 set-face global ts_text                         "%opt{fg_main}"
 set-face global ts_text_title                   "%opt{fg_main}+b"

--- a/colors/modus-operandi-tinted.kak
+++ b/colors/modus-operandi-tinted.kak
@@ -30,6 +30,14 @@ declare-option str blue_warmer 'rgb:3546c2'
 declare-option str cyan 'rgb:00598b'
 declare-option str cyan_warmer 'rgb:32548f'
 declare-option str cyan_cooler 'rgb:005f5f'
+declare-option str red_faint 'rgb:7f0000'
+declare-option str green_faint 'rgb:2a5045'
+declare-option str yellow_faint 'rgb:574316'
+declare-option str blue_faint 'rgb:003497'
+declare-option str magenta_faint 'rgb:7c318f'
+declare-option str cyan_faint 'rgb:304463'
+declare-option str fg_link 'rgb:3546c2'
+declare-option str fg_prose_code 'rgb:00603f'
 
 declare-option str psel 'rgb:c2bcb5'
 declare-option str ssel 'rgb:f1d5d0'
@@ -54,14 +62,14 @@ set-face global comma 'rgb:000000'
 set-face global bracket 'rgb:7fdfcf'
 
 # For markup
-set-face global title "%opt{purple}"
-set-face global header "%opt{yellow_bright}"
-set-face global bold "%opt{purple}"
-set-face global italic "%opt{purple_bright}"
-set-face global mono "%opt{green}"
-set-face global block "%opt{blue_bright}"
-set-face global link "%opt{green}"
-set-face global bullet "%opt{green}"
+set-face global title "%opt{fg_main}+b"
+set-face global header "%opt{fg_main}+b"
+set-face global bold "%opt{fg_main}+b"
+set-face global italic "%opt{fg_main}+i"
+set-face global mono "%opt{fg_prose_code}"
+set-face global block "%opt{fg_dim}"
+set-face global link "%opt{fg_link}+u"
+set-face global bullet "%opt{fg_dim}"
 set-face global list "%opt{fg_main}"
 
 # Builtin faces
@@ -157,23 +165,23 @@ set-face global ts_markup_bold                  "%opt{fg_main}+b"
 set-face global ts_markup_italic                "%opt{fg_main}+i"
 set-face global ts_markup_strikethrough         "%opt{fg_dim}+s"
 set-face global ts_markup_heading               "%opt{fg_main}+b"
-set-face global ts_markup_heading_1             "%opt{red}+b"
-set-face global ts_markup_heading_2             "%opt{purple_bright}+b"
-set-face global ts_markup_heading_3             "%opt{green}+b"
-set-face global ts_markup_heading_4             "%opt{yellow}+b"
-set-face global ts_markup_heading_5             "%opt{purple}+b"
-set-face global ts_markup_heading_6             "%opt{cyan}+b"
-set-face global ts_markup_heading_marker        "%opt{red}+b"
-set-face global ts_markup_list_checked          "%opt{green}"
-set-face global ts_markup_list_numbered         "%opt{blue}+i"
-set-face global ts_markup_list_unchecked        "%opt{cyan}"
-set-face global ts_markup_list_unnumbered       "%opt{purple_bright}"
-set-face global ts_markup_link_label            "%opt{blue}"
-set-face global ts_markup_link_url              "%opt{cyan}+u"
-set-face global ts_markup_link_uri              "%opt{cyan}+u"
-set-face global ts_markup_link_text             "%opt{blue}"
-set-face global ts_markup_quote                 "%opt{fg_dim}+i"
-set-face global ts_markup_raw                   "%opt{green_bright}"
+set-face global ts_markup_heading_1             "%opt{fg_main}+b"
+set-face global ts_markup_heading_2             "%opt{yellow_faint}+b"
+set-face global ts_markup_heading_3             "%opt{fg_alt}+b"
+set-face global ts_markup_heading_4             "%opt{purple}+b"
+set-face global ts_markup_heading_5             "%opt{green_faint}+b"
+set-face global ts_markup_heading_6             "%opt{red_faint}+b"
+set-face global ts_markup_heading_marker        "%opt{fg_dim}"
+set-face global ts_markup_list_checked          "%opt{fg_dim}"
+set-face global ts_markup_list_numbered         "%opt{fg_dim}"
+set-face global ts_markup_list_unchecked        "%opt{fg_dim}"
+set-face global ts_markup_list_unnumbered       "%opt{fg_dim}"
+set-face global ts_markup_link_label            "%opt{fg_link}"
+set-face global ts_markup_link_url              "%opt{fg_alt}"
+set-face global ts_markup_link_uri              "%opt{fg_alt}"
+set-face global ts_markup_link_text             "%opt{fg_link}+u"
+set-face global ts_markup_quote                 "%opt{fg_main}+i"
+set-face global ts_markup_raw                   "%opt{fg_prose_code}"
 
 # -- Diff --
 set-face global ts_diff_plus                    "%opt{green}"
@@ -194,7 +202,7 @@ set-face global ts_load                         "%opt{purple_bright}"
 set-face global ts_tag                          "%opt{purple_bright}"
 set-face global ts_tag_error                    "%opt{red}"
 set-face global ts_text                         "%opt{fg_main}"
-set-face global ts_text_title                   "%opt{purple_bright}+b"
+set-face global ts_text_title                   "%opt{fg_main}+b"
 set-face global ts_conceal                      "%opt{fg_dim}+i"
 set-face global ts_special                      "%opt{blue}"
 set-face global ts_spell                        "%opt{fg_main}"

--- a/colors/modus-operandi-tritanopia.kak
+++ b/colors/modus-operandi-tritanopia.kak
@@ -149,8 +149,8 @@ set-face global ts_variable_other_member        "%opt{cyan_cooler}"
 set-face global ts_variable_parameter           "%opt{cyan_cooler}+i"
 
 # -- Comments & operators --
-set-face global ts_comment                      "%opt{red_faint}+i"
-set-face global ts_comment_unused               "%opt{red_faint}+is"
+set-face global ts_comment                      "%opt{red_faint}"
+set-face global ts_comment_unused               "%opt{red_faint}+s"
 set-face global ts_operator                     "%opt{fg_main}"
 set-face global ts_punctuation                  "%opt{fg_main}"
 set-face global ts_punctuation_special          "%opt{red_bright}"

--- a/colors/modus-operandi-tritanopia.kak
+++ b/colors/modus-operandi-tritanopia.kak
@@ -7,7 +7,7 @@ declare-option str fg_main 'rgb:000000'
 declare-option str bg_dim 'rgb:f2f2f2'
 declare-option str fg_dim 'rgb:595959'
 declare-option str bg_alt 'rgb:c4c4c4'
-declare-option str fg_alt 'rgb:193668'
+declare-option str fg_alt 'rgb:224960'
 declare-option str bg_active 'rgb:c4c4c4'
 declare-option str bg_inactive 'rgb:e0e0e0'
 declare-option str red 'rgb:a60000'
@@ -21,8 +21,8 @@ declare-option str blue_bright 'rgb:0000b0'
 declare-option str purple 'rgb:721045'
 declare-option str purple_bright 'rgb:531ab6'
 declare-option str bg_mode_line 'rgb:afe0f2'
-declare-option str fg_mode_line 'rgb:000000'
-declare-option str cursor 'rgb:000000'
+declare-option str fg_mode_line 'rgb:0f0f0f'
+declare-option str cursor 'rgb:d00000'
 declare-option str bg_hl_line 'rgb:dfeaec'
 declare-option str fg_space 'rgb:9f9f9f'
 declare-option str magenta_warmer 'rgb:8f0075'
@@ -38,6 +38,7 @@ declare-option str magenta_faint 'rgb:7c318f'
 declare-option str cyan_faint 'rgb:004f5f'
 declare-option str fg_link 'rgb:005e8b'
 declare-option str fg_prose_code 'rgb:005e8b'
+declare-option str red_warmer 'rgb:b21100'
 
 declare-option str psel 'rgb:bdbdbd'
 declare-option str ssel 'rgb:dfeaec'
@@ -101,64 +102,64 @@ set-face global BufferPadding "%opt{bg_main},%opt{bg_main}"
 
 # For tree-sitter (kak-tree-sitter)
 # -- Keywords --
-set-face global ts_keyword                      "%opt{purple_bright}"
-set-face global ts_keyword_conditional          "%opt{purple_bright}+i"
-set-face global ts_keyword_control_conditional  "%opt{purple_bright}+i"
-set-face global ts_keyword_control_import       "%opt{purple_bright}+i"
-set-face global ts_keyword_directive            "%opt{red_bright}+i"
-set-face global ts_keyword_storage              "%opt{purple_bright}"
-set-face global ts_keyword_storage_modifier     "%opt{purple_bright}"
-set-face global ts_keyword_storage_modifier_mut "%opt{purple_bright}"
-set-face global ts_keyword_storage_modifier_ref "%opt{cyan_cooler}"
+set-face global ts_keyword                      "%opt{red_bright}"
+set-face global ts_keyword_conditional          "%opt{red_bright}+i"
+set-face global ts_keyword_control_conditional  "%opt{red_bright}+i"
+set-face global ts_keyword_control_import       "%opt{red_bright}+i"
+set-face global ts_keyword_directive            "%opt{red_warmer}+i"
+set-face global ts_keyword_storage              "%opt{red_bright}"
+set-face global ts_keyword_storage_modifier     "%opt{red_bright}"
+set-face global ts_keyword_storage_modifier_mut "%opt{red_bright}"
+set-face global ts_keyword_storage_modifier_ref "%opt{blue_warmer}"
 
 # -- Functions --
-set-face global ts_function                     "%opt{purple}"
-set-face global ts_function_builtin             "%opt{magenta_warmer}+i"
-set-face global ts_function_macro               "%opt{red_bright}"
-set-face global ts_function_method              "%opt{purple}"
+set-face global ts_function                     "%opt{cyan_warmer}"
+set-face global ts_function_builtin             "%opt{purple}+i"
+set-face global ts_function_macro               "%opt{red_warmer}"
+set-face global ts_function_method              "%opt{cyan_warmer}"
 
 # -- Types --
-set-face global ts_type                         "%opt{cyan_cooler}"
-set-face global ts_type_builtin                 "%opt{cyan_cooler}"
+set-face global ts_type                         "%opt{blue_warmer}"
+set-face global ts_type_builtin                 "%opt{blue_warmer}"
 set-face global ts_type_enum_variant            "%opt{cyan_warmer}"
-set-face global ts_type_parameter               "%opt{cyan}+i"
-set-face global ts_constructor                  "%opt{cyan_cooler}"
+set-face global ts_type_parameter               "%opt{cyan_cooler}+i"
+set-face global ts_constructor                  "%opt{blue_warmer}"
 
 # -- Strings --
-set-face global ts_string                       "%opt{blue_warmer}"
-set-face global ts_string_regexp                "%opt{green_bright}"
+set-face global ts_string                       "%opt{cyan}"
+set-face global ts_string_regexp                "%opt{red}"
 set-face global ts_string_escape                "%opt{purple}"
-set-face global ts_string_special               "%opt{blue}"
+set-face global ts_string_special               "%opt{cyan}"
 set-face global ts_string_special_path          "%opt{green_bright}"
-set-face global ts_string_special_symbol        "%opt{purple_bright}"
-set-face global ts_string_symbol                "%opt{red_bright}"
+set-face global ts_string_special_symbol        "%opt{red_bright}"
+set-face global ts_string_symbol                "%opt{red_warmer}"
 
 # -- Constants --
-set-face global ts_constant                     "%opt{blue_bright}"
-set-face global ts_constant_builtin             "%opt{blue_bright}"
-set-face global ts_constant_builtin_boolean     "%opt{blue_bright}"
-set-face global ts_constant_character           "%opt{blue_bright}"
-set-face global ts_constant_macro               "%opt{red_bright}"
-set-face global ts_constant_numeric             "%opt{blue_bright}"
+set-face global ts_constant                     "%opt{green_bright}"
+set-face global ts_constant_builtin             "%opt{green_bright}"
+set-face global ts_constant_builtin_boolean     "%opt{green_bright}"
+set-face global ts_constant_character           "%opt{green_bright}"
+set-face global ts_constant_macro               "%opt{red_warmer}"
+set-face global ts_constant_numeric             "%opt{fg_main}"
 
 # -- Variables --
-set-face global ts_variable                     "%opt{cyan}"
-set-face global ts_variable_builtin             "%opt{purple_bright}"
-set-face global ts_variable_other_member        "%opt{cyan_warmer}"
-set-face global ts_variable_parameter           "%opt{cyan}+i"
+set-face global ts_variable                     "%opt{cyan_cooler}"
+set-face global ts_variable_builtin             "%opt{red_bright}"
+set-face global ts_variable_other_member        "%opt{cyan_cooler}"
+set-face global ts_variable_parameter           "%opt{cyan_cooler}+i"
 
 # -- Comments & operators --
-set-face global ts_comment                      "%opt{fg_dim}+i"
-set-face global ts_comment_unused               "%opt{fg_dim}+is"
+set-face global ts_comment                      "%opt{red_faint}+i"
+set-face global ts_comment_unused               "%opt{red_faint}+is"
 set-face global ts_operator                     "%opt{fg_main}"
-set-face global ts_punctuation                  "%opt{fg_dim}"
-set-face global ts_punctuation_special          "%opt{purple_bright}"
+set-face global ts_punctuation                  "%opt{fg_main}"
+set-face global ts_punctuation_special          "%opt{red_bright}"
 
 # -- Properties, namespaces, labels --
-set-face global ts_property                     "%opt{cyan}"
-set-face global ts_namespace                    "%opt{cyan}+i"
-set-face global ts_label                        "%opt{cyan}+i"
-set-face global ts_attribute                    "%opt{red_bright}"
+set-face global ts_property                     "%opt{cyan_cooler}"
+set-face global ts_namespace                    "%opt{blue_warmer}+i"
+set-face global ts_label                        "%opt{cyan_cooler}+i"
+set-face global ts_attribute                    "%opt{red_warmer}"
 
 # -- Markup --
 set-face global ts_markup_bold                  "%opt{fg_main}+b"
@@ -196,10 +197,10 @@ set-face global ts_hint                         "%opt{blue}+b"
 set-face global ts_info                         "%opt{green}+b"
 
 # -- Others --
-set-face global ts_embedded                     "%opt{purple_bright}"
-set-face global ts_include                      "%opt{purple_bright}"
-set-face global ts_load                         "%opt{purple_bright}"
-set-face global ts_tag                          "%opt{purple_bright}"
+set-face global ts_embedded                     "%opt{red_bright}"
+set-face global ts_include                      "%opt{red_bright}"
+set-face global ts_load                         "%opt{red_bright}"
+set-face global ts_tag                          "%opt{red_bright}"
 set-face global ts_tag_error                    "%opt{red}"
 set-face global ts_text                         "%opt{fg_main}"
 set-face global ts_text_title                   "%opt{fg_main}+b"

--- a/colors/modus-operandi-tritanopia.kak
+++ b/colors/modus-operandi-tritanopia.kak
@@ -30,6 +30,14 @@ declare-option str blue_warmer 'rgb:3548cf'
 declare-option str cyan 'rgb:005e8b'
 declare-option str cyan_warmer 'rgb:3f578f'
 declare-option str cyan_cooler 'rgb:005f5f'
+declare-option str red_faint 'rgb:702000'
+declare-option str green_faint 'rgb:2a5045'
+declare-option str yellow_faint 'rgb:624416'
+declare-option str blue_faint 'rgb:003497'
+declare-option str magenta_faint 'rgb:7c318f'
+declare-option str cyan_faint 'rgb:004f5f'
+declare-option str fg_link 'rgb:005e8b'
+declare-option str fg_prose_code 'rgb:005e8b'
 
 declare-option str psel 'rgb:bdbdbd'
 declare-option str ssel 'rgb:dfeaec'
@@ -54,14 +62,14 @@ set-face global comma 'rgb:000000'
 set-face global bracket 'rgb:5fcfff'
 
 # For markup
-set-face global title "%opt{purple}"
-set-face global header "%opt{yellow_bright}"
-set-face global bold "%opt{purple}"
-set-face global italic "%opt{purple_bright}"
-set-face global mono "%opt{green}"
-set-face global block "%opt{blue_bright}"
-set-face global link "%opt{green}"
-set-face global bullet "%opt{green}"
+set-face global title "%opt{fg_main}+b"
+set-face global header "%opt{fg_main}+b"
+set-face global bold "%opt{fg_main}+b"
+set-face global italic "%opt{fg_main}+i"
+set-face global mono "%opt{fg_prose_code}"
+set-face global block "%opt{fg_dim}"
+set-face global link "%opt{fg_link}+u"
+set-face global bullet "%opt{fg_dim}"
 set-face global list "%opt{fg_main}"
 
 # Builtin faces
@@ -157,23 +165,23 @@ set-face global ts_markup_bold                  "%opt{fg_main}+b"
 set-face global ts_markup_italic                "%opt{fg_main}+i"
 set-face global ts_markup_strikethrough         "%opt{fg_dim}+s"
 set-face global ts_markup_heading               "%opt{fg_main}+b"
-set-face global ts_markup_heading_1             "%opt{red}+b"
-set-face global ts_markup_heading_2             "%opt{purple_bright}+b"
-set-face global ts_markup_heading_3             "%opt{green}+b"
-set-face global ts_markup_heading_4             "%opt{yellow}+b"
-set-face global ts_markup_heading_5             "%opt{purple}+b"
-set-face global ts_markup_heading_6             "%opt{cyan}+b"
-set-face global ts_markup_heading_marker        "%opt{red}+b"
-set-face global ts_markup_list_checked          "%opt{green}"
-set-face global ts_markup_list_numbered         "%opt{blue}+i"
-set-face global ts_markup_list_unchecked        "%opt{cyan}"
-set-face global ts_markup_list_unnumbered       "%opt{purple_bright}"
-set-face global ts_markup_link_label            "%opt{blue}"
-set-face global ts_markup_link_url              "%opt{cyan}+u"
-set-face global ts_markup_link_uri              "%opt{cyan}+u"
-set-face global ts_markup_link_text             "%opt{blue}"
-set-face global ts_markup_quote                 "%opt{fg_dim}+i"
-set-face global ts_markup_raw                   "%opt{green_bright}"
+set-face global ts_markup_heading_1             "%opt{fg_main}+b"
+set-face global ts_markup_heading_2             "%opt{red_faint}+b"
+set-face global ts_markup_heading_3             "%opt{cyan_faint}+b"
+set-face global ts_markup_heading_4             "%opt{purple}+b"
+set-face global ts_markup_heading_5             "%opt{green_faint}+b"
+set-face global ts_markup_heading_6             "%opt{magenta_faint}+b"
+set-face global ts_markup_heading_marker        "%opt{fg_dim}"
+set-face global ts_markup_list_checked          "%opt{fg_dim}"
+set-face global ts_markup_list_numbered         "%opt{fg_dim}"
+set-face global ts_markup_list_unchecked        "%opt{fg_dim}"
+set-face global ts_markup_list_unnumbered       "%opt{fg_dim}"
+set-face global ts_markup_link_label            "%opt{fg_link}"
+set-face global ts_markup_link_url              "%opt{fg_alt}"
+set-face global ts_markup_link_uri              "%opt{fg_alt}"
+set-face global ts_markup_link_text             "%opt{fg_link}+u"
+set-face global ts_markup_quote                 "%opt{fg_main}+i"
+set-face global ts_markup_raw                   "%opt{fg_prose_code}"
 
 # -- Diff --
 set-face global ts_diff_plus                    "%opt{green}"
@@ -194,7 +202,7 @@ set-face global ts_load                         "%opt{purple_bright}"
 set-face global ts_tag                          "%opt{purple_bright}"
 set-face global ts_tag_error                    "%opt{red}"
 set-face global ts_text                         "%opt{fg_main}"
-set-face global ts_text_title                   "%opt{purple_bright}+b"
+set-face global ts_text_title                   "%opt{fg_main}+b"
 set-face global ts_conceal                      "%opt{fg_dim}+i"
 set-face global ts_special                      "%opt{blue}"
 set-face global ts_spell                        "%opt{fg_main}"

--- a/colors/modus-operandi.kak
+++ b/colors/modus-operandi.kak
@@ -139,7 +139,7 @@ set-face global ts_constant_builtin             "%opt{blue_bright}"
 set-face global ts_constant_builtin_boolean     "%opt{blue_bright}"
 set-face global ts_constant_character           "%opt{blue_bright}"
 set-face global ts_constant_macro               "%opt{red_bright}"
-set-face global ts_constant_numeric             "%opt{blue_bright}"
+set-face global ts_constant_numeric             "%opt{fg_main}"
 
 # -- Variables --
 set-face global ts_variable                     "%opt{cyan}"
@@ -151,7 +151,7 @@ set-face global ts_variable_parameter           "%opt{cyan}+i"
 set-face global ts_comment                      "%opt{fg_dim}+i"
 set-face global ts_comment_unused               "%opt{fg_dim}+is"
 set-face global ts_operator                     "%opt{fg_main}"
-set-face global ts_punctuation                  "%opt{fg_dim}"
+set-face global ts_punctuation                  "%opt{fg_main}"
 set-face global ts_punctuation_special          "%opt{purple_bright}"
 
 # -- Properties, namespaces, labels --

--- a/colors/modus-operandi.kak
+++ b/colors/modus-operandi.kak
@@ -148,8 +148,8 @@ set-face global ts_variable_other_member        "%opt{cyan_warmer}"
 set-face global ts_variable_parameter           "%opt{cyan}+i"
 
 # -- Comments & operators --
-set-face global ts_comment                      "%opt{fg_dim}+i"
-set-face global ts_comment_unused               "%opt{fg_dim}+is"
+set-face global ts_comment                      "%opt{fg_dim}"
+set-face global ts_comment_unused               "%opt{fg_dim}+s"
 set-face global ts_operator                     "%opt{fg_main}"
 set-face global ts_punctuation                  "%opt{fg_main}"
 set-face global ts_punctuation_special          "%opt{purple_bright}"

--- a/colors/modus-operandi.kak
+++ b/colors/modus-operandi.kak
@@ -30,6 +30,14 @@ declare-option str blue_warmer 'rgb:3548cf'
 declare-option str cyan 'rgb:005e8b'
 declare-option str cyan_warmer 'rgb:3f578f'
 declare-option str cyan_cooler 'rgb:005f5f'
+declare-option str red_faint 'rgb:7f0000'
+declare-option str green_faint 'rgb:2a5045'
+declare-option str yellow_faint 'rgb:624416'
+declare-option str blue_faint 'rgb:003497'
+declare-option str magenta_faint 'rgb:7c318f'
+declare-option str cyan_faint 'rgb:005077'
+declare-option str fg_link 'rgb:3548cf'
+declare-option str fg_prose_code 'rgb:005f5f'
 
 declare-option str psel 'rgb:bdbdbd'
 declare-option str ssel 'rgb:dae5ec'
@@ -54,14 +62,14 @@ set-face global comma 'rgb:000000'
 set-face global bracket 'rgb:5fcfff'
 
 # For markup
-set-face global title "%opt{purple}"
-set-face global header "%opt{yellow_bright}"
-set-face global bold "%opt{purple}"
-set-face global italic "%opt{purple_bright}"
-set-face global mono "%opt{green}"
-set-face global block "%opt{blue_bright}"
-set-face global link "%opt{green}"
-set-face global bullet "%opt{green}"
+set-face global title "%opt{fg_main}+b"
+set-face global header "%opt{fg_main}+b"
+set-face global bold "%opt{fg_main}+b"
+set-face global italic "%opt{fg_main}+i"
+set-face global mono "%opt{fg_prose_code}"
+set-face global block "%opt{fg_dim}"
+set-face global link "%opt{fg_link}+u"
+set-face global bullet "%opt{fg_dim}"
 set-face global list "%opt{fg_main}"
 
 # Builtin faces
@@ -157,23 +165,23 @@ set-face global ts_markup_bold                  "%opt{fg_main}+b"
 set-face global ts_markup_italic                "%opt{fg_main}+i"
 set-face global ts_markup_strikethrough         "%opt{fg_dim}+s"
 set-face global ts_markup_heading               "%opt{fg_main}+b"
-set-face global ts_markup_heading_1             "%opt{red}+b"
-set-face global ts_markup_heading_2             "%opt{purple_bright}+b"
-set-face global ts_markup_heading_3             "%opt{green}+b"
-set-face global ts_markup_heading_4             "%opt{yellow}+b"
-set-face global ts_markup_heading_5             "%opt{purple}+b"
-set-face global ts_markup_heading_6             "%opt{cyan}+b"
-set-face global ts_markup_heading_marker        "%opt{red}+b"
-set-face global ts_markup_list_checked          "%opt{green}"
-set-face global ts_markup_list_numbered         "%opt{blue}+i"
-set-face global ts_markup_list_unchecked        "%opt{cyan}"
-set-face global ts_markup_list_unnumbered       "%opt{purple_bright}"
-set-face global ts_markup_link_label            "%opt{blue}"
-set-face global ts_markup_link_url              "%opt{cyan}+u"
-set-face global ts_markup_link_uri              "%opt{cyan}+u"
-set-face global ts_markup_link_text             "%opt{blue}"
-set-face global ts_markup_quote                 "%opt{fg_dim}+i"
-set-face global ts_markup_raw                   "%opt{green_bright}"
+set-face global ts_markup_heading_1             "%opt{fg_main}+b"
+set-face global ts_markup_heading_2             "%opt{yellow_faint}+b"
+set-face global ts_markup_heading_3             "%opt{fg_alt}+b"
+set-face global ts_markup_heading_4             "%opt{purple}+b"
+set-face global ts_markup_heading_5             "%opt{green_faint}+b"
+set-face global ts_markup_heading_6             "%opt{red_faint}+b"
+set-face global ts_markup_heading_marker        "%opt{fg_dim}"
+set-face global ts_markup_list_checked          "%opt{fg_dim}"
+set-face global ts_markup_list_numbered         "%opt{fg_dim}"
+set-face global ts_markup_list_unchecked        "%opt{fg_dim}"
+set-face global ts_markup_list_unnumbered       "%opt{fg_dim}"
+set-face global ts_markup_link_label            "%opt{fg_link}"
+set-face global ts_markup_link_url              "%opt{fg_alt}"
+set-face global ts_markup_link_uri              "%opt{fg_alt}"
+set-face global ts_markup_link_text             "%opt{fg_link}+u"
+set-face global ts_markup_quote                 "%opt{fg_main}+i"
+set-face global ts_markup_raw                   "%opt{fg_prose_code}"
 
 # -- Diff --
 set-face global ts_diff_plus                    "%opt{green}"
@@ -194,7 +202,7 @@ set-face global ts_load                         "%opt{purple_bright}"
 set-face global ts_tag                          "%opt{purple_bright}"
 set-face global ts_tag_error                    "%opt{red}"
 set-face global ts_text                         "%opt{fg_main}"
-set-face global ts_text_title                   "%opt{purple_bright}+b"
+set-face global ts_text_title                   "%opt{fg_main}+b"
 set-face global ts_conceal                      "%opt{fg_dim}+i"
 set-face global ts_special                      "%opt{blue}"
 set-face global ts_spell                        "%opt{fg_main}"

--- a/colors/modus-vivendi-deuteranopia.kak
+++ b/colors/modus-vivendi-deuteranopia.kak
@@ -149,8 +149,8 @@ set-face global ts_variable_other_member        "%opt{cyan_warmer}"
 set-face global ts_variable_parameter           "%opt{cyan}+i"
 
 # -- Comments & operators --
-set-face global ts_comment                      "%opt{yellow_bright}+i"
-set-face global ts_comment_unused               "%opt{yellow_bright}+is"
+set-face global ts_comment                      "%opt{yellow_bright}"
+set-face global ts_comment_unused               "%opt{yellow_bright}+s"
 set-face global ts_operator                     "%opt{fg_main}"
 set-face global ts_punctuation                  "%opt{fg_main}"
 set-face global ts_punctuation_special          "%opt{blue_bright}"

--- a/colors/modus-vivendi-deuteranopia.kak
+++ b/colors/modus-vivendi-deuteranopia.kak
@@ -21,8 +21,8 @@ declare-option str blue_bright 'rgb:00bcff'
 declare-option str purple 'rgb:feacd0'
 declare-option str purple_bright 'rgb:b6a0ff'
 declare-option str bg_mode_line 'rgb:2a2a6a'
-declare-option str fg_mode_line 'rgb:ffffff'
-declare-option str cursor 'rgb:ffffff'
+declare-option str fg_mode_line 'rgb:f0f0f0'
+declare-option str cursor 'rgb:efef00'
 declare-option str bg_hl_line 'rgb:2f3849'
 declare-option str fg_space 'rgb:646464'
 declare-option str magenta_warmer 'rgb:f78fe7'
@@ -38,6 +38,7 @@ declare-option str magenta_faint 'rgb:caa6df'
 declare-option str cyan_faint 'rgb:9ac8e0'
 declare-option str fg_link 'rgb:79a8ff'
 declare-option str fg_prose_code 'rgb:6ae4b9'
+declare-option str yellow_warmer 'rgb:ffa00f'
 
 declare-option str psel 'rgb:5a5a5a'
 declare-option str ssel 'rgb:2f3849'
@@ -48,14 +49,14 @@ declare-option str ssel 'rgb:2f3849'
 set-face global value 'rgb:ffffff'
 set-face global type 'rgb:6ae4b9'
 set-face global variable 'rgb:00d3d0'
-set-face global keyword 'rgb:b6a0ff'
+set-face global keyword 'rgb:00bcff'
 set-face global module 'rgb:ffffff'
-set-face global function 'rgb:feacd0'
+set-face global function 'rgb:ffa00f'
 set-face global string 'rgb:79a8ff'
-set-face global builtin 'rgb:f78fe7'
-set-face global constant 'rgb:00bcff'
+set-face global builtin 'rgb:cabf00'
+set-face global constant 'rgb:82b0ec'
 set-face global comment 'rgb:d8af7a'
-set-face global meta 'rgb:ff7f86'
+set-face global meta 'rgb:b6a0ff'
 
 set-face global operator 'rgb:ffffff'
 set-face global comma 'rgb:ffffff'
@@ -101,21 +102,21 @@ set-face global BufferPadding "%opt{bg_main},%opt{bg_main}"
 
 # For tree-sitter (kak-tree-sitter)
 # -- Keywords --
-set-face global ts_keyword                      "%opt{purple_bright}"
-set-face global ts_keyword_conditional          "%opt{purple_bright}+i"
-set-face global ts_keyword_control_conditional  "%opt{purple_bright}+i"
-set-face global ts_keyword_control_import       "%opt{purple_bright}+i"
-set-face global ts_keyword_directive            "%opt{red_bright}+i"
-set-face global ts_keyword_storage              "%opt{purple_bright}"
-set-face global ts_keyword_storage_modifier     "%opt{purple_bright}"
-set-face global ts_keyword_storage_modifier_mut "%opt{purple_bright}"
+set-face global ts_keyword                      "%opt{blue_bright}"
+set-face global ts_keyword_conditional          "%opt{blue_bright}+i"
+set-face global ts_keyword_control_conditional  "%opt{blue_bright}+i"
+set-face global ts_keyword_control_import       "%opt{blue_bright}+i"
+set-face global ts_keyword_directive            "%opt{purple_bright}+i"
+set-face global ts_keyword_storage              "%opt{blue_bright}"
+set-face global ts_keyword_storage_modifier     "%opt{blue_bright}"
+set-face global ts_keyword_storage_modifier_mut "%opt{blue_bright}"
 set-face global ts_keyword_storage_modifier_ref "%opt{cyan_cooler}"
 
 # -- Functions --
-set-face global ts_function                     "%opt{purple}"
-set-face global ts_function_builtin             "%opt{magenta_warmer}+i"
-set-face global ts_function_macro               "%opt{red_bright}"
-set-face global ts_function_method              "%opt{purple}"
+set-face global ts_function                     "%opt{yellow_warmer}"
+set-face global ts_function_builtin             "%opt{yellow}+i"
+set-face global ts_function_macro               "%opt{purple_bright}"
+set-face global ts_function_method              "%opt{yellow_warmer}"
 
 # -- Types --
 set-face global ts_type                         "%opt{cyan_cooler}"
@@ -126,39 +127,39 @@ set-face global ts_constructor                  "%opt{cyan_cooler}"
 
 # -- Strings --
 set-face global ts_string                       "%opt{blue_warmer}"
-set-face global ts_string_regexp                "%opt{green_bright}"
-set-face global ts_string_escape                "%opt{purple}"
+set-face global ts_string_regexp                "%opt{yellow_bright}"
+set-face global ts_string_escape                "%opt{blue_bright}"
 set-face global ts_string_special               "%opt{blue}"
 set-face global ts_string_special_path          "%opt{green_bright}"
-set-face global ts_string_special_symbol        "%opt{purple_bright}"
-set-face global ts_string_symbol                "%opt{red_bright}"
+set-face global ts_string_special_symbol        "%opt{blue_bright}"
+set-face global ts_string_symbol                "%opt{purple_bright}"
 
 # -- Constants --
-set-face global ts_constant                     "%opt{blue_bright}"
-set-face global ts_constant_builtin             "%opt{blue_bright}"
-set-face global ts_constant_builtin_boolean     "%opt{blue_bright}"
-set-face global ts_constant_character           "%opt{blue_bright}"
-set-face global ts_constant_macro               "%opt{red_bright}"
-set-face global ts_constant_numeric             "%opt{blue_bright}"
+set-face global ts_constant                     "%opt{blue_faint}"
+set-face global ts_constant_builtin             "%opt{blue_faint}"
+set-face global ts_constant_builtin_boolean     "%opt{blue_faint}"
+set-face global ts_constant_character           "%opt{blue_faint}"
+set-face global ts_constant_macro               "%opt{purple_bright}"
+set-face global ts_constant_numeric             "%opt{fg_main}"
 
 # -- Variables --
 set-face global ts_variable                     "%opt{cyan}"
-set-face global ts_variable_builtin             "%opt{purple_bright}"
+set-face global ts_variable_builtin             "%opt{blue_bright}"
 set-face global ts_variable_other_member        "%opt{cyan_warmer}"
 set-face global ts_variable_parameter           "%opt{cyan}+i"
 
 # -- Comments & operators --
-set-face global ts_comment                      "%opt{fg_dim}+i"
-set-face global ts_comment_unused               "%opt{fg_dim}+is"
+set-face global ts_comment                      "%opt{yellow_bright}+i"
+set-face global ts_comment_unused               "%opt{yellow_bright}+is"
 set-face global ts_operator                     "%opt{fg_main}"
-set-face global ts_punctuation                  "%opt{fg_dim}"
-set-face global ts_punctuation_special          "%opt{purple_bright}"
+set-face global ts_punctuation                  "%opt{fg_main}"
+set-face global ts_punctuation_special          "%opt{blue_bright}"
 
 # -- Properties, namespaces, labels --
 set-face global ts_property                     "%opt{cyan}"
-set-face global ts_namespace                    "%opt{cyan}+i"
+set-face global ts_namespace                    "%opt{cyan_cooler}+i"
 set-face global ts_label                        "%opt{cyan}+i"
-set-face global ts_attribute                    "%opt{red_bright}"
+set-face global ts_attribute                    "%opt{purple_bright}"
 
 # -- Markup --
 set-face global ts_markup_bold                  "%opt{fg_main}+b"
@@ -196,10 +197,10 @@ set-face global ts_hint                         "%opt{blue}+b"
 set-face global ts_info                         "%opt{green}+b"
 
 # -- Others --
-set-face global ts_embedded                     "%opt{purple_bright}"
-set-face global ts_include                      "%opt{purple_bright}"
-set-face global ts_load                         "%opt{purple_bright}"
-set-face global ts_tag                          "%opt{purple_bright}"
+set-face global ts_embedded                     "%opt{blue_bright}"
+set-face global ts_include                      "%opt{blue_bright}"
+set-face global ts_load                         "%opt{blue_bright}"
+set-face global ts_tag                          "%opt{blue_bright}"
 set-face global ts_tag_error                    "%opt{red}"
 set-face global ts_text                         "%opt{fg_main}"
 set-face global ts_text_title                   "%opt{fg_main}+b"

--- a/colors/modus-vivendi-deuteranopia.kak
+++ b/colors/modus-vivendi-deuteranopia.kak
@@ -30,6 +30,14 @@ declare-option str blue_warmer 'rgb:79a8ff'
 declare-option str cyan 'rgb:00d3d0'
 declare-option str cyan_warmer 'rgb:4ae2f0'
 declare-option str cyan_cooler 'rgb:6ae4b9'
+declare-option str red_faint 'rgb:ff9580'
+declare-option str green_faint 'rgb:88ca9f'
+declare-option str yellow_faint 'rgb:d2b580'
+declare-option str blue_faint 'rgb:82b0ec'
+declare-option str magenta_faint 'rgb:caa6df'
+declare-option str cyan_faint 'rgb:9ac8e0'
+declare-option str fg_link 'rgb:79a8ff'
+declare-option str fg_prose_code 'rgb:6ae4b9'
 
 declare-option str psel 'rgb:5a5a5a'
 declare-option str ssel 'rgb:2f3849'
@@ -54,14 +62,14 @@ set-face global comma 'rgb:ffffff'
 set-face global bracket 'rgb:2f7f9f'
 
 # For markup
-set-face global title "%opt{purple}"
-set-face global header "%opt{yellow_bright}"
-set-face global bold "%opt{purple}"
-set-face global italic "%opt{purple_bright}"
-set-face global mono "%opt{green}"
-set-face global block "%opt{blue_bright}"
-set-face global link "%opt{green}"
-set-face global bullet "%opt{green}"
+set-face global title "%opt{fg_main}+b"
+set-face global header "%opt{fg_main}+b"
+set-face global bold "%opt{fg_main}+b"
+set-face global italic "%opt{fg_main}+i"
+set-face global mono "%opt{fg_prose_code}"
+set-face global block "%opt{fg_dim}"
+set-face global link "%opt{fg_link}+u"
+set-face global bullet "%opt{fg_dim}"
 set-face global list "%opt{fg_main}"
 
 # Builtin faces
@@ -157,23 +165,23 @@ set-face global ts_markup_bold                  "%opt{fg_main}+b"
 set-face global ts_markup_italic                "%opt{fg_main}+i"
 set-face global ts_markup_strikethrough         "%opt{fg_dim}+s"
 set-face global ts_markup_heading               "%opt{fg_main}+b"
-set-face global ts_markup_heading_1             "%opt{red}+b"
-set-face global ts_markup_heading_2             "%opt{purple_bright}+b"
-set-face global ts_markup_heading_3             "%opt{green}+b"
-set-face global ts_markup_heading_4             "%opt{yellow}+b"
-set-face global ts_markup_heading_5             "%opt{purple}+b"
-set-face global ts_markup_heading_6             "%opt{cyan}+b"
-set-face global ts_markup_heading_marker        "%opt{red}+b"
-set-face global ts_markup_list_checked          "%opt{green}"
-set-face global ts_markup_list_numbered         "%opt{blue}+i"
-set-face global ts_markup_list_unchecked        "%opt{cyan}"
-set-face global ts_markup_list_unnumbered       "%opt{purple_bright}"
-set-face global ts_markup_link_label            "%opt{blue}"
-set-face global ts_markup_link_url              "%opt{cyan}+u"
-set-face global ts_markup_link_uri              "%opt{cyan}+u"
-set-face global ts_markup_link_text             "%opt{blue}"
-set-face global ts_markup_quote                 "%opt{fg_dim}+i"
-set-face global ts_markup_raw                   "%opt{green_bright}"
+set-face global ts_markup_heading_1             "%opt{fg_main}+b"
+set-face global ts_markup_heading_2             "%opt{yellow_faint}+b"
+set-face global ts_markup_heading_3             "%opt{blue_faint}+b"
+set-face global ts_markup_heading_4             "%opt{green_faint}+b"
+set-face global ts_markup_heading_5             "%opt{purple_bright}+b"
+set-face global ts_markup_heading_6             "%opt{yellow_bright}+b"
+set-face global ts_markup_heading_marker        "%opt{fg_dim}"
+set-face global ts_markup_list_checked          "%opt{fg_dim}"
+set-face global ts_markup_list_numbered         "%opt{fg_dim}"
+set-face global ts_markup_list_unchecked        "%opt{fg_dim}"
+set-face global ts_markup_list_unnumbered       "%opt{fg_dim}"
+set-face global ts_markup_link_label            "%opt{fg_link}"
+set-face global ts_markup_link_url              "%opt{fg_alt}"
+set-face global ts_markup_link_uri              "%opt{fg_alt}"
+set-face global ts_markup_link_text             "%opt{fg_link}+u"
+set-face global ts_markup_quote                 "%opt{fg_main}+i"
+set-face global ts_markup_raw                   "%opt{fg_prose_code}"
 
 # -- Diff --
 set-face global ts_diff_plus                    "%opt{green}"
@@ -194,7 +202,7 @@ set-face global ts_load                         "%opt{purple_bright}"
 set-face global ts_tag                          "%opt{purple_bright}"
 set-face global ts_tag_error                    "%opt{red}"
 set-face global ts_text                         "%opt{fg_main}"
-set-face global ts_text_title                   "%opt{purple_bright}+b"
+set-face global ts_text_title                   "%opt{fg_main}+b"
 set-face global ts_conceal                      "%opt{fg_dim}+i"
 set-face global ts_special                      "%opt{blue}"
 set-face global ts_spell                        "%opt{fg_main}"

--- a/colors/modus-vivendi-tinted.kak
+++ b/colors/modus-vivendi-tinted.kak
@@ -13,7 +13,7 @@ declare-option str bg_inactive 'rgb:2b3045'
 declare-option str red 'rgb:ff5f59'
 declare-option str red_bright 'rgb:ff7f86'
 declare-option str green 'rgb:44bc44'
-declare-option str green_bright 'rgb:00c06f'
+declare-option str green_bright 'rgb:11c777'
 declare-option str yellow 'rgb:d0bc00'
 declare-option str yellow_bright 'rgb:dfaf7a'
 declare-option str blue 'rgb:2fafff'
@@ -22,7 +22,7 @@ declare-option str purple 'rgb:feacd0'
 declare-option str purple_bright 'rgb:b6a0ff'
 declare-option str bg_mode_line 'rgb:484d67'
 declare-option str fg_mode_line 'rgb:ffffff'
-declare-option str cursor 'rgb:ffffff'
+declare-option str cursor 'rgb:ff66ff'
 declare-option str bg_hl_line 'rgb:303a6f'
 declare-option str fg_space 'rgb:61647a'
 declare-option str magenta_warmer 'rgb:f78fe7'
@@ -46,15 +46,15 @@ declare-option str ssel 'rgb:303a6f'
 # https://github.com/mawww/kakoune/blob/master/colors/default.kak
 # For code
 set-face global value 'rgb:ffffff'
-set-face global type 'rgb:6ae4b9'
-set-face global variable 'rgb:00d3d0'
-set-face global keyword 'rgb:b6a0ff'
+set-face global type 'rgb:11c777'
+set-face global variable 'rgb:4ae2f0'
+set-face global keyword 'rgb:79a8ff'
 set-face global module 'rgb:ffffff'
-set-face global function 'rgb:feacd0'
-set-face global string 'rgb:79a8ff'
-set-face global builtin 'rgb:f78fe7'
-set-face global constant 'rgb:00bcff'
-set-face global comment 'rgb:ff9f80'
+set-face global function 'rgb:f78fe7'
+set-face global string 'rgb:2fafff'
+set-face global builtin 'rgb:feacd0'
+set-face global constant 'rgb:b6a0ff'
+set-face global comment 'rgb:ef8386'
 set-face global meta 'rgb:ff7f86'
 
 set-face global operator 'rgb:ffffff'
@@ -101,63 +101,63 @@ set-face global BufferPadding "%opt{bg_main},%opt{bg_main}"
 
 # For tree-sitter (kak-tree-sitter)
 # -- Keywords --
-set-face global ts_keyword                      "%opt{purple_bright}"
-set-face global ts_keyword_conditional          "%opt{purple_bright}+i"
-set-face global ts_keyword_control_conditional  "%opt{purple_bright}+i"
-set-face global ts_keyword_control_import       "%opt{purple_bright}+i"
+set-face global ts_keyword                      "%opt{blue_warmer}"
+set-face global ts_keyword_conditional          "%opt{blue_warmer}+i"
+set-face global ts_keyword_control_conditional  "%opt{blue_warmer}+i"
+set-face global ts_keyword_control_import       "%opt{blue_warmer}+i"
 set-face global ts_keyword_directive            "%opt{red_bright}+i"
-set-face global ts_keyword_storage              "%opt{purple_bright}"
-set-face global ts_keyword_storage_modifier     "%opt{purple_bright}"
-set-face global ts_keyword_storage_modifier_mut "%opt{purple_bright}"
-set-face global ts_keyword_storage_modifier_ref "%opt{cyan_cooler}"
+set-face global ts_keyword_storage              "%opt{blue_warmer}"
+set-face global ts_keyword_storage_modifier     "%opt{blue_warmer}"
+set-face global ts_keyword_storage_modifier_mut "%opt{blue_warmer}"
+set-face global ts_keyword_storage_modifier_ref "%opt{green_bright}"
 
 # -- Functions --
-set-face global ts_function                     "%opt{purple}"
-set-face global ts_function_builtin             "%opt{magenta_warmer}+i"
+set-face global ts_function                     "%opt{magenta_warmer}"
+set-face global ts_function_builtin             "%opt{purple}+i"
 set-face global ts_function_macro               "%opt{red_bright}"
-set-face global ts_function_method              "%opt{purple}"
+set-face global ts_function_method              "%opt{magenta_warmer}"
 
 # -- Types --
-set-face global ts_type                         "%opt{cyan_cooler}"
-set-face global ts_type_builtin                 "%opt{cyan_cooler}"
-set-face global ts_type_enum_variant            "%opt{cyan_warmer}"
-set-face global ts_type_parameter               "%opt{cyan}+i"
-set-face global ts_constructor                  "%opt{cyan_cooler}"
+set-face global ts_type                         "%opt{green_bright}"
+set-face global ts_type_builtin                 "%opt{green_bright}"
+set-face global ts_type_enum_variant            "%opt{cyan_cooler}"
+set-face global ts_type_parameter               "%opt{cyan_warmer}+i"
+set-face global ts_constructor                  "%opt{green_bright}"
 
 # -- Strings --
-set-face global ts_string                       "%opt{blue_warmer}"
-set-face global ts_string_regexp                "%opt{green_bright}"
-set-face global ts_string_escape                "%opt{purple}"
+set-face global ts_string                       "%opt{blue}"
+set-face global ts_string_regexp                "%opt{purple_bright}"
+set-face global ts_string_escape                "%opt{magenta_warmer}"
 set-face global ts_string_special               "%opt{blue}"
 set-face global ts_string_special_path          "%opt{green_bright}"
-set-face global ts_string_special_symbol        "%opt{purple_bright}"
+set-face global ts_string_special_symbol        "%opt{blue_warmer}"
 set-face global ts_string_symbol                "%opt{red_bright}"
 
 # -- Constants --
-set-face global ts_constant                     "%opt{blue_bright}"
-set-face global ts_constant_builtin             "%opt{blue_bright}"
-set-face global ts_constant_builtin_boolean     "%opt{blue_bright}"
-set-face global ts_constant_character           "%opt{blue_bright}"
+set-face global ts_constant                     "%opt{purple_bright}"
+set-face global ts_constant_builtin             "%opt{purple_bright}"
+set-face global ts_constant_builtin_boolean     "%opt{purple_bright}"
+set-face global ts_constant_character           "%opt{purple_bright}"
 set-face global ts_constant_macro               "%opt{red_bright}"
-set-face global ts_constant_numeric             "%opt{blue_bright}"
+set-face global ts_constant_numeric             "%opt{fg_main}"
 
 # -- Variables --
-set-face global ts_variable                     "%opt{cyan}"
-set-face global ts_variable_builtin             "%opt{purple_bright}"
+set-face global ts_variable                     "%opt{cyan_warmer}"
+set-face global ts_variable_builtin             "%opt{blue_warmer}"
 set-face global ts_variable_other_member        "%opt{cyan_warmer}"
-set-face global ts_variable_parameter           "%opt{cyan}+i"
+set-face global ts_variable_parameter           "%opt{cyan_warmer}+i"
 
 # -- Comments & operators --
-set-face global ts_comment                      "%opt{fg_dim}+i"
-set-face global ts_comment_unused               "%opt{fg_dim}+is"
+set-face global ts_comment                      "%opt{red_faint}+i"
+set-face global ts_comment_unused               "%opt{red_faint}+is"
 set-face global ts_operator                     "%opt{fg_main}"
-set-face global ts_punctuation                  "%opt{fg_dim}"
-set-face global ts_punctuation_special          "%opt{purple_bright}"
+set-face global ts_punctuation                  "%opt{fg_main}"
+set-face global ts_punctuation_special          "%opt{blue_warmer}"
 
 # -- Properties, namespaces, labels --
-set-face global ts_property                     "%opt{cyan}"
-set-face global ts_namespace                    "%opt{cyan}+i"
-set-face global ts_label                        "%opt{cyan}+i"
+set-face global ts_property                     "%opt{cyan_warmer}"
+set-face global ts_namespace                    "%opt{green_bright}+i"
+set-face global ts_label                        "%opt{cyan_warmer}+i"
 set-face global ts_attribute                    "%opt{red_bright}"
 
 # -- Markup --
@@ -196,10 +196,10 @@ set-face global ts_hint                         "%opt{blue}+b"
 set-face global ts_info                         "%opt{green}+b"
 
 # -- Others --
-set-face global ts_embedded                     "%opt{purple_bright}"
-set-face global ts_include                      "%opt{purple_bright}"
-set-face global ts_load                         "%opt{purple_bright}"
-set-face global ts_tag                          "%opt{purple_bright}"
+set-face global ts_embedded                     "%opt{blue_warmer}"
+set-face global ts_include                      "%opt{blue_warmer}"
+set-face global ts_load                         "%opt{blue_warmer}"
+set-face global ts_tag                          "%opt{blue_warmer}"
 set-face global ts_tag_error                    "%opt{red}"
 set-face global ts_text                         "%opt{fg_main}"
 set-face global ts_text_title                   "%opt{fg_main}+b"

--- a/colors/modus-vivendi-tinted.kak
+++ b/colors/modus-vivendi-tinted.kak
@@ -30,6 +30,14 @@ declare-option str blue_warmer 'rgb:79a8ff'
 declare-option str cyan 'rgb:00d3d0'
 declare-option str cyan_warmer 'rgb:4ae2f0'
 declare-option str cyan_cooler 'rgb:6ae4b9'
+declare-option str red_faint 'rgb:ef8386'
+declare-option str green_faint 'rgb:88ca9f'
+declare-option str yellow_faint 'rgb:d2b580'
+declare-option str blue_faint 'rgb:82b0ec'
+declare-option str magenta_faint 'rgb:caa6df'
+declare-option str cyan_faint 'rgb:9ac8e0'
+declare-option str fg_link 'rgb:79a8ff'
+declare-option str fg_prose_code 'rgb:6ae4b9'
 
 declare-option str psel 'rgb:555a66'
 declare-option str ssel 'rgb:303a6f'
@@ -54,14 +62,14 @@ set-face global comma 'rgb:ffffff'
 set-face global bracket 'rgb:2f7f9f'
 
 # For markup
-set-face global title "%opt{purple}"
-set-face global header "%opt{yellow_bright}"
-set-face global bold "%opt{purple}"
-set-face global italic "%opt{purple_bright}"
-set-face global mono "%opt{green}"
-set-face global block "%opt{blue_bright}"
-set-face global link "%opt{green}"
-set-face global bullet "%opt{green}"
+set-face global title "%opt{fg_main}+b"
+set-face global header "%opt{fg_main}+b"
+set-face global bold "%opt{fg_main}+b"
+set-face global italic "%opt{fg_main}+i"
+set-face global mono "%opt{fg_prose_code}"
+set-face global block "%opt{fg_dim}"
+set-face global link "%opt{fg_link}+u"
+set-face global bullet "%opt{fg_dim}"
 set-face global list "%opt{fg_main}"
 
 # Builtin faces
@@ -157,23 +165,23 @@ set-face global ts_markup_bold                  "%opt{fg_main}+b"
 set-face global ts_markup_italic                "%opt{fg_main}+i"
 set-face global ts_markup_strikethrough         "%opt{fg_dim}+s"
 set-face global ts_markup_heading               "%opt{fg_main}+b"
-set-face global ts_markup_heading_1             "%opt{red}+b"
-set-face global ts_markup_heading_2             "%opt{purple_bright}+b"
-set-face global ts_markup_heading_3             "%opt{green}+b"
-set-face global ts_markup_heading_4             "%opt{yellow}+b"
-set-face global ts_markup_heading_5             "%opt{purple}+b"
-set-face global ts_markup_heading_6             "%opt{cyan}+b"
-set-face global ts_markup_heading_marker        "%opt{red}+b"
-set-face global ts_markup_list_checked          "%opt{green}"
-set-face global ts_markup_list_numbered         "%opt{blue}+i"
-set-face global ts_markup_list_unchecked        "%opt{cyan}"
-set-face global ts_markup_list_unnumbered       "%opt{purple_bright}"
-set-face global ts_markup_link_label            "%opt{blue}"
-set-face global ts_markup_link_url              "%opt{cyan}+u"
-set-face global ts_markup_link_uri              "%opt{cyan}+u"
-set-face global ts_markup_link_text             "%opt{blue}"
-set-face global ts_markup_quote                 "%opt{fg_dim}+i"
-set-face global ts_markup_raw                   "%opt{green_bright}"
+set-face global ts_markup_heading_1             "%opt{fg_main}+b"
+set-face global ts_markup_heading_2             "%opt{yellow_faint}+b"
+set-face global ts_markup_heading_3             "%opt{blue_faint}+b"
+set-face global ts_markup_heading_4             "%opt{purple}+b"
+set-face global ts_markup_heading_5             "%opt{green_faint}+b"
+set-face global ts_markup_heading_6             "%opt{red_faint}+b"
+set-face global ts_markup_heading_marker        "%opt{fg_dim}"
+set-face global ts_markup_list_checked          "%opt{fg_dim}"
+set-face global ts_markup_list_numbered         "%opt{fg_dim}"
+set-face global ts_markup_list_unchecked        "%opt{fg_dim}"
+set-face global ts_markup_list_unnumbered       "%opt{fg_dim}"
+set-face global ts_markup_link_label            "%opt{fg_link}"
+set-face global ts_markup_link_url              "%opt{fg_alt}"
+set-face global ts_markup_link_uri              "%opt{fg_alt}"
+set-face global ts_markup_link_text             "%opt{fg_link}+u"
+set-face global ts_markup_quote                 "%opt{fg_main}+i"
+set-face global ts_markup_raw                   "%opt{fg_prose_code}"
 
 # -- Diff --
 set-face global ts_diff_plus                    "%opt{green}"
@@ -194,7 +202,7 @@ set-face global ts_load                         "%opt{purple_bright}"
 set-face global ts_tag                          "%opt{purple_bright}"
 set-face global ts_tag_error                    "%opt{red}"
 set-face global ts_text                         "%opt{fg_main}"
-set-face global ts_text_title                   "%opt{purple_bright}+b"
+set-face global ts_text_title                   "%opt{fg_main}+b"
 set-face global ts_conceal                      "%opt{fg_dim}+i"
 set-face global ts_special                      "%opt{blue}"
 set-face global ts_spell                        "%opt{fg_main}"

--- a/colors/modus-vivendi-tinted.kak
+++ b/colors/modus-vivendi-tinted.kak
@@ -148,8 +148,8 @@ set-face global ts_variable_other_member        "%opt{cyan_warmer}"
 set-face global ts_variable_parameter           "%opt{cyan_warmer}+i"
 
 # -- Comments & operators --
-set-face global ts_comment                      "%opt{red_faint}+i"
-set-face global ts_comment_unused               "%opt{red_faint}+is"
+set-face global ts_comment                      "%opt{red_faint}"
+set-face global ts_comment_unused               "%opt{red_faint}+s"
 set-face global ts_operator                     "%opt{fg_main}"
 set-face global ts_punctuation                  "%opt{fg_main}"
 set-face global ts_punctuation_special          "%opt{blue_warmer}"

--- a/colors/modus-vivendi-tritanopia.kak
+++ b/colors/modus-vivendi-tritanopia.kak
@@ -7,7 +7,7 @@ declare-option str fg_main 'rgb:ffffff'
 declare-option str bg_dim 'rgb:1e1e1e'
 declare-option str fg_dim 'rgb:989898'
 declare-option str bg_alt 'rgb:535353'
-declare-option str fg_alt 'rgb:c6daff'
+declare-option str fg_alt 'rgb:a0d7f2'
 declare-option str bg_active 'rgb:535353'
 declare-option str bg_inactive 'rgb:303030'
 declare-option str red 'rgb:ff5f59'
@@ -21,8 +21,8 @@ declare-option str blue_bright 'rgb:00bcff'
 declare-option str purple 'rgb:feacd0'
 declare-option str purple_bright 'rgb:b6a0ff'
 declare-option str bg_mode_line 'rgb:003c52'
-declare-option str fg_mode_line 'rgb:ffffff'
-declare-option str cursor 'rgb:ffffff'
+declare-option str fg_mode_line 'rgb:f0f0f0'
+declare-option str cursor 'rgb:ff5f5f'
 declare-option str bg_hl_line 'rgb:2f3849'
 declare-option str fg_space 'rgb:646464'
 declare-option str magenta_warmer 'rgb:f78fe7'
@@ -38,6 +38,7 @@ declare-option str magenta_faint 'rgb:caa6df'
 declare-option str cyan_faint 'rgb:7fdbdf'
 declare-option str fg_link 'rgb:00d3d0'
 declare-option str fg_prose_code 'rgb:00d3d0'
+declare-option str red_warmer 'rgb:ff6740'
 
 declare-option str psel 'rgb:5a5a5a'
 declare-option str ssel 'rgb:2f3849'
@@ -101,64 +102,64 @@ set-face global BufferPadding "%opt{bg_main},%opt{bg_main}"
 
 # For tree-sitter (kak-tree-sitter)
 # -- Keywords --
-set-face global ts_keyword                      "%opt{purple_bright}"
-set-face global ts_keyword_conditional          "%opt{purple_bright}+i"
-set-face global ts_keyword_control_conditional  "%opt{purple_bright}+i"
-set-face global ts_keyword_control_import       "%opt{purple_bright}+i"
-set-face global ts_keyword_directive            "%opt{red_bright}+i"
-set-face global ts_keyword_storage              "%opt{purple_bright}"
-set-face global ts_keyword_storage_modifier     "%opt{purple_bright}"
-set-face global ts_keyword_storage_modifier_mut "%opt{purple_bright}"
-set-face global ts_keyword_storage_modifier_ref "%opt{cyan_cooler}"
+set-face global ts_keyword                      "%opt{red_bright}"
+set-face global ts_keyword_conditional          "%opt{red_bright}+i"
+set-face global ts_keyword_control_conditional  "%opt{red_bright}+i"
+set-face global ts_keyword_control_import       "%opt{red_bright}+i"
+set-face global ts_keyword_directive            "%opt{red_warmer}+i"
+set-face global ts_keyword_storage              "%opt{red_bright}"
+set-face global ts_keyword_storage_modifier     "%opt{red_bright}"
+set-face global ts_keyword_storage_modifier_mut "%opt{red_bright}"
+set-face global ts_keyword_storage_modifier_ref "%opt{blue_warmer}"
 
 # -- Functions --
-set-face global ts_function                     "%opt{purple}"
-set-face global ts_function_builtin             "%opt{magenta_warmer}+i"
-set-face global ts_function_macro               "%opt{red_bright}"
-set-face global ts_function_method              "%opt{purple}"
+set-face global ts_function                     "%opt{cyan_warmer}"
+set-face global ts_function_builtin             "%opt{purple}+i"
+set-face global ts_function_macro               "%opt{red_warmer}"
+set-face global ts_function_method              "%opt{cyan_warmer}"
 
 # -- Types --
-set-face global ts_type                         "%opt{cyan_cooler}"
-set-face global ts_type_builtin                 "%opt{cyan_cooler}"
+set-face global ts_type                         "%opt{blue_warmer}"
+set-face global ts_type_builtin                 "%opt{blue_warmer}"
 set-face global ts_type_enum_variant            "%opt{cyan_warmer}"
-set-face global ts_type_parameter               "%opt{cyan}+i"
-set-face global ts_constructor                  "%opt{cyan_cooler}"
+set-face global ts_type_parameter               "%opt{cyan_cooler}+i"
+set-face global ts_constructor                  "%opt{blue_warmer}"
 
 # -- Strings --
-set-face global ts_string                       "%opt{blue_warmer}"
-set-face global ts_string_regexp                "%opt{green_bright}"
+set-face global ts_string                       "%opt{cyan}"
+set-face global ts_string_regexp                "%opt{red}"
 set-face global ts_string_escape                "%opt{purple}"
-set-face global ts_string_special               "%opt{blue}"
+set-face global ts_string_special               "%opt{cyan}"
 set-face global ts_string_special_path          "%opt{green_bright}"
-set-face global ts_string_special_symbol        "%opt{purple_bright}"
-set-face global ts_string_symbol                "%opt{red_bright}"
+set-face global ts_string_special_symbol        "%opt{red_bright}"
+set-face global ts_string_symbol                "%opt{red_warmer}"
 
 # -- Constants --
-set-face global ts_constant                     "%opt{blue_bright}"
-set-face global ts_constant_builtin             "%opt{blue_bright}"
-set-face global ts_constant_builtin_boolean     "%opt{blue_bright}"
-set-face global ts_constant_character           "%opt{blue_bright}"
-set-face global ts_constant_macro               "%opt{red_bright}"
-set-face global ts_constant_numeric             "%opt{blue_bright}"
+set-face global ts_constant                     "%opt{green_faint}"
+set-face global ts_constant_builtin             "%opt{green_faint}"
+set-face global ts_constant_builtin_boolean     "%opt{green_faint}"
+set-face global ts_constant_character           "%opt{green_faint}"
+set-face global ts_constant_macro               "%opt{red_warmer}"
+set-face global ts_constant_numeric             "%opt{fg_main}"
 
 # -- Variables --
-set-face global ts_variable                     "%opt{cyan}"
-set-face global ts_variable_builtin             "%opt{purple_bright}"
-set-face global ts_variable_other_member        "%opt{cyan_warmer}"
-set-face global ts_variable_parameter           "%opt{cyan}+i"
+set-face global ts_variable                     "%opt{cyan_cooler}"
+set-face global ts_variable_builtin             "%opt{red_bright}"
+set-face global ts_variable_other_member        "%opt{cyan_cooler}"
+set-face global ts_variable_parameter           "%opt{cyan_cooler}+i"
 
 # -- Comments & operators --
-set-face global ts_comment                      "%opt{fg_dim}+i"
-set-face global ts_comment_unused               "%opt{fg_dim}+is"
+set-face global ts_comment                      "%opt{red_faint}+i"
+set-face global ts_comment_unused               "%opt{red_faint}+is"
 set-face global ts_operator                     "%opt{fg_main}"
-set-face global ts_punctuation                  "%opt{fg_dim}"
-set-face global ts_punctuation_special          "%opt{purple_bright}"
+set-face global ts_punctuation                  "%opt{fg_main}"
+set-face global ts_punctuation_special          "%opt{red_bright}"
 
 # -- Properties, namespaces, labels --
-set-face global ts_property                     "%opt{cyan}"
-set-face global ts_namespace                    "%opt{cyan}+i"
-set-face global ts_label                        "%opt{cyan}+i"
-set-face global ts_attribute                    "%opt{red_bright}"
+set-face global ts_property                     "%opt{cyan_cooler}"
+set-face global ts_namespace                    "%opt{blue_warmer}+i"
+set-face global ts_label                        "%opt{cyan_cooler}+i"
+set-face global ts_attribute                    "%opt{red_warmer}"
 
 # -- Markup --
 set-face global ts_markup_bold                  "%opt{fg_main}+b"
@@ -196,10 +197,10 @@ set-face global ts_hint                         "%opt{blue}+b"
 set-face global ts_info                         "%opt{green}+b"
 
 # -- Others --
-set-face global ts_embedded                     "%opt{purple_bright}"
-set-face global ts_include                      "%opt{purple_bright}"
-set-face global ts_load                         "%opt{purple_bright}"
-set-face global ts_tag                          "%opt{purple_bright}"
+set-face global ts_embedded                     "%opt{red_bright}"
+set-face global ts_include                      "%opt{red_bright}"
+set-face global ts_load                         "%opt{red_bright}"
+set-face global ts_tag                          "%opt{red_bright}"
 set-face global ts_tag_error                    "%opt{red}"
 set-face global ts_text                         "%opt{fg_main}"
 set-face global ts_text_title                   "%opt{fg_main}+b"

--- a/colors/modus-vivendi-tritanopia.kak
+++ b/colors/modus-vivendi-tritanopia.kak
@@ -30,6 +30,14 @@ declare-option str blue_warmer 'rgb:79a8ff'
 declare-option str cyan 'rgb:00d3d0'
 declare-option str cyan_warmer 'rgb:4ae2ff'
 declare-option str cyan_cooler 'rgb:6ae4b9'
+declare-option str red_faint 'rgb:ff9070'
+declare-option str green_faint 'rgb:88ca9f'
+declare-option str yellow_faint 'rgb:d2b580'
+declare-option str blue_faint 'rgb:82b0ec'
+declare-option str magenta_faint 'rgb:caa6df'
+declare-option str cyan_faint 'rgb:7fdbdf'
+declare-option str fg_link 'rgb:00d3d0'
+declare-option str fg_prose_code 'rgb:00d3d0'
 
 declare-option str psel 'rgb:5a5a5a'
 declare-option str ssel 'rgb:2f3849'
@@ -54,14 +62,14 @@ set-face global comma 'rgb:ffffff'
 set-face global bracket 'rgb:2f7f9f'
 
 # For markup
-set-face global title "%opt{purple}"
-set-face global header "%opt{yellow_bright}"
-set-face global bold "%opt{purple}"
-set-face global italic "%opt{purple_bright}"
-set-face global mono "%opt{green}"
-set-face global block "%opt{blue_bright}"
-set-face global link "%opt{green}"
-set-face global bullet "%opt{green}"
+set-face global title "%opt{fg_main}+b"
+set-face global header "%opt{fg_main}+b"
+set-face global bold "%opt{fg_main}+b"
+set-face global italic "%opt{fg_main}+i"
+set-face global mono "%opt{fg_prose_code}"
+set-face global block "%opt{fg_dim}"
+set-face global link "%opt{fg_link}+u"
+set-face global bullet "%opt{fg_dim}"
 set-face global list "%opt{fg_main}"
 
 # Builtin faces
@@ -157,23 +165,23 @@ set-face global ts_markup_bold                  "%opt{fg_main}+b"
 set-face global ts_markup_italic                "%opt{fg_main}+i"
 set-face global ts_markup_strikethrough         "%opt{fg_dim}+s"
 set-face global ts_markup_heading               "%opt{fg_main}+b"
-set-face global ts_markup_heading_1             "%opt{red}+b"
-set-face global ts_markup_heading_2             "%opt{purple_bright}+b"
-set-face global ts_markup_heading_3             "%opt{green}+b"
-set-face global ts_markup_heading_4             "%opt{yellow}+b"
-set-face global ts_markup_heading_5             "%opt{purple}+b"
-set-face global ts_markup_heading_6             "%opt{cyan}+b"
-set-face global ts_markup_heading_marker        "%opt{red}+b"
-set-face global ts_markup_list_checked          "%opt{green}"
-set-face global ts_markup_list_numbered         "%opt{blue}+i"
-set-face global ts_markup_list_unchecked        "%opt{cyan}"
-set-face global ts_markup_list_unnumbered       "%opt{purple_bright}"
-set-face global ts_markup_link_label            "%opt{blue}"
-set-face global ts_markup_link_url              "%opt{cyan}+u"
-set-face global ts_markup_link_uri              "%opt{cyan}+u"
-set-face global ts_markup_link_text             "%opt{blue}"
-set-face global ts_markup_quote                 "%opt{fg_dim}+i"
-set-face global ts_markup_raw                   "%opt{green_bright}"
+set-face global ts_markup_heading_1             "%opt{fg_main}+b"
+set-face global ts_markup_heading_2             "%opt{red_faint}+b"
+set-face global ts_markup_heading_3             "%opt{cyan_faint}+b"
+set-face global ts_markup_heading_4             "%opt{purple}+b"
+set-face global ts_markup_heading_5             "%opt{green_faint}+b"
+set-face global ts_markup_heading_6             "%opt{magenta_faint}+b"
+set-face global ts_markup_heading_marker        "%opt{fg_dim}"
+set-face global ts_markup_list_checked          "%opt{fg_dim}"
+set-face global ts_markup_list_numbered         "%opt{fg_dim}"
+set-face global ts_markup_list_unchecked        "%opt{fg_dim}"
+set-face global ts_markup_list_unnumbered       "%opt{fg_dim}"
+set-face global ts_markup_link_label            "%opt{fg_link}"
+set-face global ts_markup_link_url              "%opt{fg_alt}"
+set-face global ts_markup_link_uri              "%opt{fg_alt}"
+set-face global ts_markup_link_text             "%opt{fg_link}+u"
+set-face global ts_markup_quote                 "%opt{fg_main}+i"
+set-face global ts_markup_raw                   "%opt{fg_prose_code}"
 
 # -- Diff --
 set-face global ts_diff_plus                    "%opt{green}"
@@ -194,7 +202,7 @@ set-face global ts_load                         "%opt{purple_bright}"
 set-face global ts_tag                          "%opt{purple_bright}"
 set-face global ts_tag_error                    "%opt{red}"
 set-face global ts_text                         "%opt{fg_main}"
-set-face global ts_text_title                   "%opt{purple_bright}+b"
+set-face global ts_text_title                   "%opt{fg_main}+b"
 set-face global ts_conceal                      "%opt{fg_dim}+i"
 set-face global ts_special                      "%opt{blue}"
 set-face global ts_spell                        "%opt{fg_main}"

--- a/colors/modus-vivendi-tritanopia.kak
+++ b/colors/modus-vivendi-tritanopia.kak
@@ -149,8 +149,8 @@ set-face global ts_variable_other_member        "%opt{cyan_cooler}"
 set-face global ts_variable_parameter           "%opt{cyan_cooler}+i"
 
 # -- Comments & operators --
-set-face global ts_comment                      "%opt{red_faint}+i"
-set-face global ts_comment_unused               "%opt{red_faint}+is"
+set-face global ts_comment                      "%opt{red_faint}"
+set-face global ts_comment_unused               "%opt{red_faint}+s"
 set-face global ts_operator                     "%opt{fg_main}"
 set-face global ts_punctuation                  "%opt{fg_main}"
 set-face global ts_punctuation_special          "%opt{red_bright}"

--- a/colors/modus-vivendi.kak
+++ b/colors/modus-vivendi.kak
@@ -139,7 +139,7 @@ set-face global ts_constant_builtin             "%opt{blue_bright}"
 set-face global ts_constant_builtin_boolean     "%opt{blue_bright}"
 set-face global ts_constant_character           "%opt{blue_bright}"
 set-face global ts_constant_macro               "%opt{red_bright}"
-set-face global ts_constant_numeric             "%opt{blue_bright}"
+set-face global ts_constant_numeric             "%opt{fg_main}"
 
 # -- Variables --
 set-face global ts_variable                     "%opt{cyan}"
@@ -151,7 +151,7 @@ set-face global ts_variable_parameter           "%opt{cyan}+i"
 set-face global ts_comment                      "%opt{fg_dim}+i"
 set-face global ts_comment_unused               "%opt{fg_dim}+is"
 set-face global ts_operator                     "%opt{fg_main}"
-set-face global ts_punctuation                  "%opt{fg_dim}"
+set-face global ts_punctuation                  "%opt{fg_main}"
 set-face global ts_punctuation_special          "%opt{purple_bright}"
 
 # -- Properties, namespaces, labels --

--- a/colors/modus-vivendi.kak
+++ b/colors/modus-vivendi.kak
@@ -148,8 +148,8 @@ set-face global ts_variable_other_member        "%opt{cyan_warmer}"
 set-face global ts_variable_parameter           "%opt{cyan}+i"
 
 # -- Comments & operators --
-set-face global ts_comment                      "%opt{fg_dim}+i"
-set-face global ts_comment_unused               "%opt{fg_dim}+is"
+set-face global ts_comment                      "%opt{fg_dim}"
+set-face global ts_comment_unused               "%opt{fg_dim}+s"
 set-face global ts_operator                     "%opt{fg_main}"
 set-face global ts_punctuation                  "%opt{fg_main}"
 set-face global ts_punctuation_special          "%opt{purple_bright}"

--- a/colors/modus-vivendi.kak
+++ b/colors/modus-vivendi.kak
@@ -30,6 +30,14 @@ declare-option str blue_warmer 'rgb:79a8ff'
 declare-option str cyan 'rgb:00d3d0'
 declare-option str cyan_warmer 'rgb:4ae2f0'
 declare-option str cyan_cooler 'rgb:6ae4b9'
+declare-option str red_faint 'rgb:ff9580'
+declare-option str green_faint 'rgb:88ca9f'
+declare-option str yellow_faint 'rgb:d2b580'
+declare-option str blue_faint 'rgb:82b0ec'
+declare-option str magenta_faint 'rgb:caa6df'
+declare-option str cyan_faint 'rgb:9ac8e0'
+declare-option str fg_link 'rgb:79a8ff'
+declare-option str fg_prose_code 'rgb:6ae4b9'
 
 declare-option str psel 'rgb:5a5a5a'
 declare-option str ssel 'rgb:2f3849'
@@ -54,14 +62,14 @@ set-face global comma 'rgb:ffffff'
 set-face global bracket 'rgb:2f7f9f'
 
 # For markup
-set-face global title "%opt{purple}"
-set-face global header "%opt{yellow_bright}"
-set-face global bold "%opt{purple}"
-set-face global italic "%opt{purple_bright}"
-set-face global mono "%opt{green}"
-set-face global block "%opt{blue_bright}"
-set-face global link "%opt{green}"
-set-face global bullet "%opt{green}"
+set-face global title "%opt{fg_main}+b"
+set-face global header "%opt{fg_main}+b"
+set-face global bold "%opt{fg_main}+b"
+set-face global italic "%opt{fg_main}+i"
+set-face global mono "%opt{fg_prose_code}"
+set-face global block "%opt{fg_dim}"
+set-face global link "%opt{fg_link}+u"
+set-face global bullet "%opt{fg_dim}"
 set-face global list "%opt{fg_main}"
 
 # Builtin faces
@@ -157,23 +165,23 @@ set-face global ts_markup_bold                  "%opt{fg_main}+b"
 set-face global ts_markup_italic                "%opt{fg_main}+i"
 set-face global ts_markup_strikethrough         "%opt{fg_dim}+s"
 set-face global ts_markup_heading               "%opt{fg_main}+b"
-set-face global ts_markup_heading_1             "%opt{red}+b"
-set-face global ts_markup_heading_2             "%opt{purple_bright}+b"
-set-face global ts_markup_heading_3             "%opt{green}+b"
-set-face global ts_markup_heading_4             "%opt{yellow}+b"
-set-face global ts_markup_heading_5             "%opt{purple}+b"
-set-face global ts_markup_heading_6             "%opt{cyan}+b"
-set-face global ts_markup_heading_marker        "%opt{red}+b"
-set-face global ts_markup_list_checked          "%opt{green}"
-set-face global ts_markup_list_numbered         "%opt{blue}+i"
-set-face global ts_markup_list_unchecked        "%opt{cyan}"
-set-face global ts_markup_list_unnumbered       "%opt{purple_bright}"
-set-face global ts_markup_link_label            "%opt{blue}"
-set-face global ts_markup_link_url              "%opt{cyan}+u"
-set-face global ts_markup_link_uri              "%opt{cyan}+u"
-set-face global ts_markup_link_text             "%opt{blue}"
-set-face global ts_markup_quote                 "%opt{fg_dim}+i"
-set-face global ts_markup_raw                   "%opt{green_bright}"
+set-face global ts_markup_heading_1             "%opt{fg_main}+b"
+set-face global ts_markup_heading_2             "%opt{yellow_faint}+b"
+set-face global ts_markup_heading_3             "%opt{blue_faint}+b"
+set-face global ts_markup_heading_4             "%opt{purple}+b"
+set-face global ts_markup_heading_5             "%opt{green_faint}+b"
+set-face global ts_markup_heading_6             "%opt{red_faint}+b"
+set-face global ts_markup_heading_marker        "%opt{fg_dim}"
+set-face global ts_markup_list_checked          "%opt{fg_dim}"
+set-face global ts_markup_list_numbered         "%opt{fg_dim}"
+set-face global ts_markup_list_unchecked        "%opt{fg_dim}"
+set-face global ts_markup_list_unnumbered       "%opt{fg_dim}"
+set-face global ts_markup_link_label            "%opt{fg_link}"
+set-face global ts_markup_link_url              "%opt{fg_alt}"
+set-face global ts_markup_link_uri              "%opt{fg_alt}"
+set-face global ts_markup_link_text             "%opt{fg_link}+u"
+set-face global ts_markup_quote                 "%opt{fg_main}+i"
+set-face global ts_markup_raw                   "%opt{fg_prose_code}"
 
 # -- Diff --
 set-face global ts_diff_plus                    "%opt{green}"
@@ -194,7 +202,7 @@ set-face global ts_load                         "%opt{purple_bright}"
 set-face global ts_tag                          "%opt{purple_bright}"
 set-face global ts_tag_error                    "%opt{red}"
 set-face global ts_text                         "%opt{fg_main}"
-set-face global ts_text_title                   "%opt{purple_bright}+b"
+set-face global ts_text_title                   "%opt{fg_main}+b"
 set-face global ts_conceal                      "%opt{fg_dim}+i"
 set-face global ts_special                      "%opt{blue}"
 set-face global ts_spell                        "%opt{fg_main}"


### PR DESCRIPTION
## Summary

Remove italic modifier from `ts_comment` and `ts_comment_unused` faces to match
Emacs modus-themes defaults (where italic is controlled by the
`modus-themes-italic-constructs` user option and disabled by default).

Other bold/italic modifiers are intentionally kept:
- Conditional/control keywords: italic distinguishes them from regular keywords (same color)
- Builtin functions: italic differentiates from regular functions
- Type/variable parameters: italic for distinction
- Markup quotes: italic prevents invisibility against body text
- Diagnostic faces: bold for visual emphasis

Kakoune lacks Emacs' toggle mechanism (`modus-themes-bold-constructs` /
`modus-themes-italic-constructs`), so the theme ships with sensible defaults
maintaining visual hierarchy.

Depends on #5.
Supersedes Yus314/kakoune-themes#1.

## Test plan

- [ ] Load theme and verify comments are NOT italic
- [ ] Verify conditional keywords (`if`, `else`) are still italic
- [ ] Verify builtin functions are still italic
- [ ] Verify diagnostic faces (error, warning) are still bold

🤖 Generated with [Claude Code](https://claude.com/claude-code)